### PR TITLE
Add analysis module with genre enrichment and research questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,58 @@
-# unwrapped Python Package
+# unwrapped
 
-**About**: Final project for STAT 3250 at the University of Virginia
+**STAT 3250 Final Project — University of Virginia**
 
-## Project Goals
+A Python package for exploring and analyzing a Spotify tracks dataset. We built
+tools to clean raw Spotify data, run statistical analysis on audio features,
+model track popularity, and recommend songs based on listening preferences.
 
-This package helps our STAT 3250 team explore a Spotify tracks dataset in a
-reproducible way. The project includes a loading layer, cleaning workflow,
-validation workflow, descriptive summary module, popularity modeling pipeline,
-preference scoring tool, and visualization helpers.
+## Research Questions
+
+1. **Which audio features are most associated with track popularity?**
+   We computed Pearson correlations between each audio feature and popularity,
+   then used bucket analysis to check for non-linear patterns.
+
+2. **How do genres differ in their audio profiles?**
+   We compared the top genres by their average audio features to see what makes
+   each genre sonically distinct.
+
+3. **Which tracks are unusual for their genre?**
+   By merging genre-level statistics back onto each track and computing
+   z-scores, we identified tracks whose audio features don't match their
+   genre's typical profile.
 
 ## Setup
 
-Install the package and development tools with:
+Clone the repo and install in editable mode:
 
 ```bash
+git clone https://github.com/jchardy7/unwrapped.git
+cd unwrapped
 pip install -e ".[dev]"
 ```
 
-This installs the core package dependencies listed in `pyproject.toml`,
-including pandas, numpy, matplotlib, and scikit-learn, plus pytest for testing.
+This installs all dependencies (pandas, numpy, matplotlib, scikit-learn) and
+pytest for running the test suite.
 
-## Run The Demos
+## Running the Analysis
 
-To run the cleaning workflow demo on the Spotify dataset:
-
-```bash
-python scripts/demo_cleaning.py
-```
-
-This demo loads `data/raw/spotify_data.csv`, applies the cleaning pipeline,
-prints the cleaning summary report, and shows a preview of the cleaned data.
-
-To run the validation workflow demo on the Spotify dataset:
+To run the main analysis that answers our research questions:
 
 ```bash
-python scripts/demo_validation.py
+python scripts/demo_analysis.py
 ```
 
-This demo loads `data/raw/spotify_data.csv`, validates the dataset, and prints
-the resulting summary report.
+This cleans the raw dataset, runs the full analysis pipeline, and prints
+findings for each research question with key takeaways.
 
-To run the descriptive summary demo:
+### Other Demos
 
 ```bash
-python scripts/demo_summary.py
+python scripts/demo_cleaning.py       # See what the cleaning pipeline does
+python scripts/demo_validation.py     # Run data quality checks
+python scripts/demo_summary.py        # Print descriptive statistics
+python scripts/demo_visualization.py  # Generate charts (saved to outputs/)
 ```
-
-This demo loads the dataset, computes descriptive statistics, and prints key
-findings including numeric summaries, categorical breakdowns, missing values,
-outliers, and feature correlations with popularity.
 
 ## Running Tests
 
@@ -56,96 +60,110 @@ outliers, and feature correlations with popularity.
 pytest
 ```
 
-All tests live in the `tests/` directory and cover the IO, cleaning,
-validation, summary, popularity, and preference modules.
+Tests are in the `tests/` directory. They use small hand-built DataFrames so
+they run fast and don't need the real CSV file.
 
-## How Cleaning Works
+## Project Structure
 
-The cleaning workflow runs in a fixed sequence:
-
-1. The dataset is loaded from CSV into a pandas DataFrame.
-2. If the file contains the extra `Unnamed: 0` column, it is removed.
-3. Text columns are stripped of extra whitespace, and blank strings are turned
-   into missing values.
-4. The `explicit` column is normalized into boolean values.
-5. Numeric analysis columns are coerced to numeric types with invalid strings
-   converted to missing values.
-6. Rows missing required identifiers such as `track_id`, `artists`,
-   `track_name`, and `track_genre` are dropped.
-7. Rows with invalid core numeric values, such as non-positive `tempo` or
-   `duration_ms`, or out-of-range audio features, are removed.
-8. Exact duplicate rows are dropped, and repeated `track_id` values are reduced
-   to one canonical row using completeness and popularity as tie-breakers.
-
-The cleaning entrypoint returns both the cleaned DataFrame and a report that
-summarizes what changed at each stage.
-
-## How Validation Works
-
-The validation workflow runs in a fixed sequence:
-
-1. The dataset is loaded from CSV into a pandas DataFrame.
-2. If the file contains the extra `Unnamed: 0` column, it is dropped during
-   loading.
-3. The schema check verifies that all expected Spotify fields are present.
-   Missing required columns raise a `ValueError`, while unexpected extra
-   columns produce a warning.
-4. Range checks validate selected numeric fields. `danceability`, `energy`,
-   `valence`, `acousticness`, `instrumentalness`, and `speechiness` must fall
-   between `0` and `1`. `tempo` and `duration_ms` must be positive. Any
-   failure raises a `ValueError`.
-5. A correlation check compares `energy` and `loudness`. If their correlation
-   is below `0.5`, the workflow prints a warning instead of failing.
-6. After validation passes, the report summarizes row and column counts,
-   missing values by column, duplicate rows, duplicate `track_id` values, the
-   number of unique tracks, and track IDs whose core audio features are
-   inconsistent across repeated rows.
-
-The validation entrypoint returns both the loaded DataFrame and the summary
-report.
-
-## Popularity Modeling Pipeline
-
-The popularity module trains regression models to predict track popularity from
-audio features and genre metadata.
-
-### Usage
-
-```python
-from unwrapped.popularity import run_popularity_pipeline
-
-results = run_popularity_pipeline("data/raw/spotify_data.csv")
-print(results["comparison"])
-print(results["feature_importance"])
+```
+unwrapped/
+├── data/raw/               # Raw Spotify dataset
+├── scripts/                # Demo scripts for each workflow
+│   ├── demo_analysis.py    # Main analysis (research questions)
+│   ├── demo_cleaning.py    # Cleaning pipeline demo
+│   ├── demo_summary.py     # Descriptive statistics demo
+│   ├── demo_validation.py  # Data quality checks demo
+│   └── demo_visualization.py  # Chart generation
+├── src/unwrapped/          # Package source code
+│   ├── io.py               # CSV loading
+│   ├── clean.py            # Data cleaning pipeline
+│   ├── validation.py       # Schema and range validation
+│   ├── summary.py          # Descriptive statistics / EDA
+│   ├── analysis.py         # Research question analysis
+│   ├── popularity.py       # Popularity prediction models
+│   ├── preference.py       # Song recommendation tool
+│   └── visualization.py    # Chart generation
+├── tests/                  # Unit tests for each module
+├── pyproject.toml          # Package config and dependencies
+└── README.md
 ```
 
-### How it works
+## How Each Module Works
 
-1. The dataset is loaded and validated for required columns.
-2. Missing values are handled: rows without popularity are dropped, missing
-   genres are filled with `"unknown"`, and missing numeric features are filled
-   with the column median.
-3. Identifier columns are removed and genre is one-hot encoded.
-4. A baseline linear regression and a random forest regressor are trained on an
-   80/20 train/test split.
-5. Both models are evaluated with RMSE, MAE, and R², plus 5-fold
-   cross-validation.
-6. Feature importances from the random forest are reported.
-7. Results (model comparison, feature importances, and test predictions) are
-   optionally saved as CSV files to the `outputs/` directory.
+### Data Loading (`io.py`)
 
-## Preference Scoring Tool
+Reads the raw CSV into a pandas DataFrame. Automatically removes the
+`Unnamed: 0` index column that some Spotify CSV exports include.
 
-The preference tool lets you build a personalized "taste profile" from a list
-of songs you like, then scores every track in the dataset by how closely it
-matches that profile.
+### Cleaning (`clean.py`)
 
-**How it works:** It computes the mean audio feature vector across all your
-liked songs (your taste profile), then ranks every other song in the dataset by
-cosine similarity to that profile. Scores are normalized to a 0-1 range, where
-1 is the closest match to your taste.
+Applies a fixed sequence of cleaning steps:
 
-### Usage
+1. Remove the export index column
+2. Trim whitespace from text columns, turn blanks into missing values
+3. Normalize the `explicit` column to boolean
+4. Coerce numeric columns to proper types
+5. Drop rows missing key identifiers (track_id, artists, track_name, genre)
+6. Remove rows with invalid values (negative duration, danceability > 1, etc.)
+7. Deduplicate — keep the most complete row per track_id
+
+Returns the cleaned DataFrame and a report showing what changed at each step.
+
+### Validation (`validation.py`)
+
+Checks data quality before analysis:
+
+- Are all 20 expected columns present?
+- Are numeric values within valid ranges?
+- Do energy and loudness correlate as expected?
+- Summary of missing values, duplicates, and inconsistencies
+
+### Summary (`summary.py`)
+
+Computes descriptive statistics across the dataset:
+
+- Numeric column distributions (mean, median, std, skew, kurtosis)
+- Top values for categorical columns (genres, artists)
+- Missing value counts and percentages per column
+- Outlier detection using the 1.5x IQR method
+- Pairwise correlation matrix for audio features
+- Per-feature correlation with popularity
+- Genre-level aggregations and popularity tier pivot tables
+
+Can also export results as CSV files for downstream use.
+
+### Analysis (`analysis.py`)
+
+The core analysis module that answers our research questions. This is where
+the data merging, numpy computation, and statistical analysis come together.
+
+- **Feature-popularity correlations**: Uses `np.corrcoef()` to measure how
+  each audio feature relates to popularity, with strength classification.
+- **Genre comparison**: Compares the top genres side-by-side using numpy
+  array operations to compute per-genre averages.
+- **Genre enrichment**: Computes per-genre mean and std for every audio
+  feature, combines them with `pd.concat()`, and merges them back onto each
+  track using `pd.merge()`. This enables per-track z-score computation.
+- **Genre outlier detection**: Uses the z-scores to find tracks whose audio
+  features are far from their genre's norm.
+- **Feature bucket analysis**: Splits features into equal-width bins using
+  `np.linspace()` to reveal non-linear popularity patterns.
+
+### Popularity Modeling (`popularity.py`)
+
+Trains regression models to predict track popularity from audio features:
+
+1. Validates and preprocesses the data (median imputation, one-hot encoding)
+2. Trains a baseline linear regression and a random forest
+3. Evaluates both with RMSE, MAE, R-squared, and 5-fold cross-validation
+4. Reports feature importances from the random forest
+5. Optionally saves results as CSV files
+
+### Preference Scoring (`preference.py`)
+
+A recommendation tool. You add songs you like, and it builds a "taste
+profile" (mean audio feature vector of your liked songs), then scores every
+other track by cosine similarity to your profile. Scores range from 0 to 1.
 
 ```python
 from unwrapped.io import load_data
@@ -153,65 +171,29 @@ from unwrapped.preference import LikedSongs
 
 df = load_data("data/raw/spotify_data.csv")
 
-# Create a LikedSongs object
 liked = LikedSongs(df)
-
-# Add songs by Spotify track ID or by name
-liked.add_by_id("5SuOikwiRyPMVoIQDJUgSV")
 liked.add_by_name("Blinding Lights")
-liked.add_by_name("Levitating", artist="Dua Lipa")  # use artist to disambiguate
+liked.add_by_name("Levitating", artist="Dua Lipa")
 
-# See what's in your liked list
-liked.show()
-
-# Predict preference scores for all songs
 scores = liked.predict(top_n=20)
 print(scores)
 ```
 
-### Output
-
-`predict()` returns a DataFrame sorted by `preference_score` descending:
-
-| track_id | track_name | artists | track_genre | popularity | preference_score |
-|---|---|---|---|---|---|
-| 3n3Ppam7vgaVa1iaRUIOKE | Flowers | Miley Cyrus | pop | 87 | 0.9741 |
-| ... | ... | ... | ... | ... | ... |
-
-### Saving and loading your liked list
-
-Your liked songs list can be saved to a file and reloaded in a future session,
-so you don't have to rebuild it every time:
+Liked lists can be saved to JSON and reloaded in future sessions:
 
 ```python
-# Save
 liked.save("my_likes.json")
 
-# Load in a future session
+# Later...
 liked = LikedSongs(df)
 liked.load("my_likes.json")
 ```
 
-### Parameters
+### Visualization (`visualization.py`)
 
-**`LikedSongs(df)`**
-- `df` — a DataFrame loaded via `unwrapped.io.load_data()`
+Generates matplotlib charts:
 
-**`add_by_name(track_name, artist=None)`**
-- `artist` is optional but recommended when multiple songs share the same title
+- Horizontal bar chart of top genres by track count
+- Histogram of the popularity distribution
 
-**`predict(top_n=None, exclude_liked=True)`**
-- `top_n` — return only the N highest-scoring songs (default: all songs)
-- `exclude_liked` — if `True`, your liked songs are excluded from results (default: `True`)
-
-## Visualization Demo
-
-To run the visualization workflow:
-
-```bash
-python scripts/demo_visualization.py
-```
-
-This will generate:
-- outputs/top_genres.png
-- outputs/popularity_distribution.png
+Charts are saved as PNG files to the `outputs/` directory.

--- a/scripts/demo_analysis.py
+++ b/scripts/demo_analysis.py
@@ -1,0 +1,189 @@
+"""Run the full analysis pipeline and present findings.
+
+This script cleans the raw Spotify dataset, then answers three research
+questions using the analysis module.  Results are printed to the terminal
+in a readable format with key takeaways highlighted.
+"""
+
+from unwrapped.io import DEFAULT_DATA_PATH, load_data
+from unwrapped.clean import clean_data
+from unwrapped.analysis import run_analysis
+
+
+def print_header(title):
+    """Print a prominent section header."""
+    print()
+    print("=" * 64)
+    print(f"  {title}")
+    print("=" * 64)
+
+
+def print_section(title):
+    """Print a subsection header."""
+    print()
+    print("-" * 64)
+    print(f"  {title}")
+    print("-" * 64)
+    print()
+
+
+def main():
+    # Load and clean the data before analysis
+    raw_df = load_data(DEFAULT_DATA_PATH)
+    df, cleaning_report = clean_data(raw_df)
+
+    print_header("Unwrapped: Spotify Dataset Analysis")
+
+    print(f"\nDataset size after cleaning: {len(df):,} tracks")
+    print(f"Rows removed during cleaning: {cleaning_report['rows_removed_total']:,}")
+    print(f"Unique genres: {df['track_genre'].nunique()}")
+    print(f"Unique artists: {df['artists'].nunique()}")
+
+    # Run the full analysis
+    results = run_analysis(df)
+
+    # ==================================================================
+    # Research Question 1
+    # ==================================================================
+
+    print_section(
+        "Q1: Which audio features are most associated with popularity?"
+    )
+
+    corr = results["correlations"]
+    print(corr[["feature", "correlation", "strength"]].to_string(index=False))
+
+    top = corr.iloc[0]
+    second = corr.iloc[1]
+    third = corr.iloc[2]
+
+    print(f"\nFindings:")
+    print(
+        f"  The strongest predictor of popularity is {top['feature']} "
+        f"(r = {top['correlation']:+.4f}, {top['strength']}), followed by "
+        f"{second['feature']} (r = {second['correlation']:+.4f}) and "
+        f"{third['feature']} (r = {third['correlation']:+.4f})."
+    )
+
+    # Check direction patterns
+    positive = corr[corr["direction"] == "positive"]["feature"].tolist()
+    negative = corr[corr["direction"] == "negative"]["feature"].tolist()
+
+    if positive:
+        print(
+            f"  Features with positive correlation (higher = more popular): "
+            f"{', '.join(positive)}"
+        )
+    if negative:
+        print(
+            f"  Features with negative correlation (higher = less popular): "
+            f"{', '.join(negative)}"
+        )
+
+    # Show bucket breakdown for the strongest feature
+    print(
+        f"\n  Breaking {top['feature']} into buckets to look for "
+        f"non-linear patterns:"
+    )
+    top_buckets = results["feature_buckets"][top["feature"]]
+    print()
+    print(top_buckets.to_string())
+
+    # ==================================================================
+    # Research Question 2
+    # ==================================================================
+
+    print_section("Q2: How do genres differ in their audio profiles?")
+
+    genre_comp = results["genre_comparison"]
+
+    display_cols = [
+        "genre",
+        "track_count",
+        "avg_popularity",
+        "avg_danceability",
+        "avg_energy",
+        "avg_acousticness",
+        "avg_valence",
+        "avg_tempo",
+    ]
+    available = [c for c in display_cols if c in genre_comp.columns]
+    print(genre_comp[available].to_string(index=False))
+
+    # Pull out some interesting contrasts
+    most_dance = genre_comp.loc[genre_comp["avg_danceability"].idxmax()]
+    least_dance = genre_comp.loc[genre_comp["avg_danceability"].idxmin()]
+    most_energy = genre_comp.loc[genre_comp["avg_energy"].idxmax()]
+    least_energy = genre_comp.loc[genre_comp["avg_energy"].idxmin()]
+    most_popular = genre_comp.loc[genre_comp["avg_popularity"].idxmax()]
+    least_popular = genre_comp.loc[genre_comp["avg_popularity"].idxmin()]
+    most_acoustic = genre_comp.loc[genre_comp["avg_acousticness"].idxmax()]
+
+    print(f"\nFindings:")
+    print(
+        f"  Most danceable genre: {most_dance['genre']} "
+        f"(avg = {most_dance['avg_danceability']:.2f})"
+    )
+    print(
+        f"  Least danceable genre: {least_dance['genre']} "
+        f"(avg = {least_dance['avg_danceability']:.2f})"
+    )
+    print(
+        f"  Most energetic genre: {most_energy['genre']} "
+        f"(avg = {most_energy['avg_energy']:.2f})"
+    )
+    print(
+        f"  Least energetic genre: {least_energy['genre']} "
+        f"(avg = {least_energy['avg_energy']:.2f})"
+    )
+    print(
+        f"  Most acoustic genre: {most_acoustic['genre']} "
+        f"(avg = {most_acoustic['avg_acousticness']:.2f})"
+    )
+    print(
+        f"  Highest avg popularity: {most_popular['genre']} "
+        f"({most_popular['avg_popularity']:.1f})"
+    )
+    print(
+        f"  Lowest avg popularity: {least_popular['genre']} "
+        f"({least_popular['avg_popularity']:.1f})"
+    )
+
+    # ==================================================================
+    # Research Question 3
+    # ==================================================================
+
+    print_section("Q3: Which tracks don't fit their genre?")
+
+    outliers = results["genre_outliers"]
+
+    if outliers.empty:
+        print("No strong genre outliers found with the default threshold.")
+    else:
+        print(f"Found {len(outliers)} tracks with deviation score > 2.0:\n")
+        print(outliers.to_string(index=False))
+
+        top_outlier = outliers.iloc[0]
+        print(
+            f"\nFindings:"
+            f"\n  The biggest outlier is \"{top_outlier['track_name']}\" by "
+            f"{top_outlier['artists']} in the {top_outlier['track_genre']} "
+            f"genre (deviation score = "
+            f"{top_outlier['genre_deviation_score']:.2f})."
+            f"\n  This means its audio features are very different from the "
+            f"typical {top_outlier['track_genre']} track."
+        )
+
+    # ==================================================================
+    # Summary
+    # ==================================================================
+
+    print()
+    print("=" * 64)
+    print("  Analysis complete.")
+    print("=" * 64)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unwrapped/__init__.py
+++ b/src/unwrapped/__init__.py
@@ -1,9 +1,17 @@
 """Public package interface for the unwrapped project."""
 
+from .analysis import run_analysis
 from .clean import clean_data
 from .clean import run_cleaning
 from .summary import run_summary
 from .summary import summarize_data
 from .validation import run_validation
 
-__all__ = ["clean_data", "run_cleaning", "run_summary", "run_validation", "summarize_data"]
+__all__ = [
+    "clean_data",
+    "run_analysis",
+    "run_cleaning",
+    "run_summary",
+    "run_validation",
+    "summarize_data",
+]

--- a/src/unwrapped/analysis.py
+++ b/src/unwrapped/analysis.py
@@ -1,0 +1,364 @@
+"""Analysis module for exploring the Spotify dataset.
+
+This module answers three research questions about the dataset:
+
+1. Which audio features are most associated with track popularity?
+2. How do genres differ in their audio profiles?
+3. Which tracks are unusual for their genre?
+
+The core technique is enriching track-level data with genre-level
+statistics using pd.merge(), then computing z-scores to measure how
+much each track deviates from its genre's norms.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .io import load_data
+
+AUDIO_FEATURES = [
+    "danceability",
+    "energy",
+    "loudness",
+    "speechiness",
+    "acousticness",
+    "instrumentalness",
+    "liveness",
+    "valence",
+    "tempo",
+]
+
+
+# ---------------------------------------------------------------------------
+# Genre enrichment (merge + concat)
+# ---------------------------------------------------------------------------
+
+
+def enrich_with_genre_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Merge genre-level audio feature statistics onto each track.
+
+    Computes the mean and standard deviation of each audio feature
+    per genre, then merges those columns back onto the track-level
+    DataFrame so every row knows its genre's average profile.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Spotify dataset with ``track_genre`` and audio feature columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Original DataFrame with additional ``*_genre_mean`` and
+        ``*_genre_std`` columns for each audio feature.
+    """
+
+    genre_means = df.groupby("track_genre")[AUDIO_FEATURES].mean()
+    genre_means.columns = [f"{c}_genre_mean" for c in AUDIO_FEATURES]
+
+    genre_stds = df.groupby("track_genre")[AUDIO_FEATURES].std()
+    genre_stds.columns = [f"{c}_genre_std" for c in AUDIO_FEATURES]
+
+    # Combine the two summary tables side by side
+    genre_stats = pd.concat([genre_means, genre_stds], axis=1)
+
+    # Merge genre-level stats back onto each track row
+    enriched = pd.merge(
+        df, genre_stats, left_on="track_genre", right_index=True, how="left"
+    )
+
+    return enriched
+
+
+# ---------------------------------------------------------------------------
+# Z-score deviation analysis
+# ---------------------------------------------------------------------------
+
+
+def compute_genre_deviations(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute how much each track deviates from its genre's average.
+
+    For each audio feature, a z-score is computed::
+
+        z = (track_value - genre_mean) / genre_std
+
+    An overall ``genre_deviation_score`` is the mean of absolute z-scores
+    across all features --- a single number for how "unusual" a track is
+    within its genre.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Spotify dataset with ``track_genre`` and audio feature columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Enriched DataFrame with per-feature z-score columns and an
+        overall ``genre_deviation_score``.
+    """
+
+    enriched = enrich_with_genre_stats(df)
+
+    # Build an (n_tracks x n_features) z-score matrix using numpy
+    z_scores = np.empty((len(enriched), len(AUDIO_FEATURES)))
+
+    for i, feature in enumerate(AUDIO_FEATURES):
+        values = enriched[feature].values.astype(float)
+        means = enriched[f"{feature}_genre_mean"].values.astype(float)
+        stds = enriched[f"{feature}_genre_std"].values.astype(float)
+
+        # Replace zero/NaN stds to avoid division errors for single-track genres
+        safe_stds = np.where(stds > 0, stds, np.nan)
+        z_scores[:, i] = (values - means) / safe_stds
+
+    # Overall deviation = mean absolute z-score across all features
+    enriched["genre_deviation_score"] = np.round(
+        np.nanmean(np.abs(z_scores), axis=1), 4
+    )
+
+    for i, feature in enumerate(AUDIO_FEATURES):
+        enriched[f"{feature}_zscore"] = np.round(z_scores[:, i], 4)
+
+    return enriched
+
+
+def find_genre_outliers(
+    df: pd.DataFrame,
+    threshold: float = 2.0,
+    top_n: int = 20,
+) -> pd.DataFrame:
+    """Find tracks that deviate most from their genre's typical profile.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Spotify dataset.
+    threshold : float, default 2.0
+        Minimum mean absolute z-score to count as an outlier.
+    top_n : int, default 20
+        Maximum number of outliers to return.
+
+    Returns
+    -------
+    pd.DataFrame
+        Top outlier tracks sorted by deviation score descending.
+    """
+
+    enriched = compute_genre_deviations(df)
+
+    outliers = enriched[enriched["genre_deviation_score"] > threshold].copy()
+    outliers = outliers.sort_values("genre_deviation_score", ascending=False)
+
+    output_cols = [
+        "track_id",
+        "track_name",
+        "artists",
+        "track_genre",
+        "popularity",
+        "genre_deviation_score",
+    ]
+
+    return outliers[output_cols].head(top_n).reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Feature-popularity correlations
+# ---------------------------------------------------------------------------
+
+
+def analyze_popularity_correlations(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute Pearson correlations between each audio feature and popularity.
+
+    Uses ``np.corrcoef`` and classifies each correlation by strength.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Spotify dataset with ``popularity`` and audio feature columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per feature with correlation value, absolute value,
+        direction, and strength label.  Sorted by absolute correlation
+        descending.
+    """
+
+    popularity = df["popularity"].values.astype(float)
+    results = []
+
+    for feature in AUDIO_FEATURES:
+        feature_vals = df[feature].values.astype(float)
+
+        # Drop rows where either value is NaN
+        valid = ~(np.isnan(popularity) | np.isnan(feature_vals))
+        if np.sum(valid) < 2:
+            continue
+
+        corr = np.corrcoef(popularity[valid], feature_vals[valid])[0, 1]
+        abs_corr = float(np.abs(corr))
+
+        if abs_corr >= 0.7:
+            strength = "strong"
+        elif abs_corr >= 0.4:
+            strength = "moderate"
+        elif abs_corr >= 0.2:
+            strength = "weak"
+        else:
+            strength = "very weak"
+
+        results.append({
+            "feature": feature,
+            "correlation": round(float(corr), 4),
+            "abs_correlation": round(abs_corr, 4),
+            "direction": "positive" if corr > 0 else "negative",
+            "strength": strength,
+        })
+
+    result_df = pd.DataFrame(results)
+    return result_df.sort_values(
+        "abs_correlation", ascending=False
+    ).reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Genre comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_genres(df: pd.DataFrame, top_n: int = 10) -> pd.DataFrame:
+    """Compare the most common genres by average audio profile.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Spotify dataset.
+    top_n : int, default 10
+        Number of top genres (by track count) to include.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per genre with track count, average popularity, and
+        mean values for each audio feature.
+    """
+
+    top_genres = df["track_genre"].value_counts().head(top_n).index.tolist()
+    subset = df[df["track_genre"].isin(top_genres)]
+
+    rows = []
+    for genre in top_genres:
+        genre_data = subset[subset["track_genre"] == genre]
+        feature_matrix = genre_data[AUDIO_FEATURES].values.astype(float)
+        pop_values = genre_data["popularity"].values.astype(float)
+
+        row = {
+            "genre": genre,
+            "track_count": len(genre_data),
+            "avg_popularity": round(float(np.nanmean(pop_values)), 1),
+        }
+
+        for i, feature in enumerate(AUDIO_FEATURES):
+            row[f"avg_{feature}"] = round(
+                float(np.nanmean(feature_matrix[:, i])), 4
+            )
+
+        rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Feature bucket analysis
+# ---------------------------------------------------------------------------
+
+
+def popularity_by_feature_buckets(
+    df: pd.DataFrame,
+    feature: str,
+    n_buckets: int = 5,
+) -> pd.DataFrame:
+    """Split a feature into equal-width buckets and show avg popularity.
+
+    This reveals non-linear relationships between a feature and
+    popularity that a single correlation number might miss.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Spotify dataset.
+    feature : str
+        Audio feature column to bucket.
+    n_buckets : int, default 5
+        Number of equal-width bins to create.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per bucket with ``avg_popularity`` and ``track_count``.
+    """
+
+    tmp = df[[feature, "popularity"]].dropna().copy()
+    values = tmp[feature].values.astype(float)
+
+    # Create evenly spaced bucket edges with numpy
+    edges = np.linspace(np.min(values), np.max(values), n_buckets + 1)
+    labels = [f"{edges[i]:.2f}-{edges[i + 1]:.2f}" for i in range(n_buckets)]
+
+    tmp["bucket"] = pd.cut(
+        tmp[feature], bins=edges, labels=labels, include_lowest=True
+    )
+
+    bucket_stats = (
+        tmp.groupby("bucket", observed=False)
+        .agg(
+            avg_popularity=("popularity", "mean"),
+            track_count=("popularity", "count"),
+        )
+        .round(2)
+    )
+
+    return bucket_stats
+
+
+# ---------------------------------------------------------------------------
+# Full analysis runner
+# ---------------------------------------------------------------------------
+
+
+def run_analysis(df: pd.DataFrame) -> dict[str, object]:
+    """Run the full analysis pipeline and return structured results.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Cleaned Spotify dataset.
+
+    Returns
+    -------
+    dict[str, object]
+        Keys: ``correlations``, ``genre_comparison``, ``genre_outliers``,
+        ``enriched_data``, ``feature_buckets``.
+    """
+
+    correlations = analyze_popularity_correlations(df)
+    genre_comparison = compare_genres(df)
+    genre_outliers = find_genre_outliers(df)
+    enriched = enrich_with_genre_stats(df)
+
+    # Run bucket analysis for the top 3 most correlated features
+    top_features = correlations.head(3)["feature"].tolist()
+    bucket_analyses = {}
+    for feature in top_features:
+        bucket_analyses[feature] = popularity_by_feature_buckets(df, feature)
+
+    return {
+        "correlations": correlations,
+        "genre_comparison": genre_comparison,
+        "genre_outliers": genre_outliers,
+        "enriched_data": enriched,
+        "feature_buckets": bucket_analyses,
+    }

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,332 @@
+"""Tests for the analysis module in :mod:`unwrapped.analysis`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from unwrapped.analysis import (
+    AUDIO_FEATURES,
+    analyze_popularity_correlations,
+    compare_genres,
+    compute_genre_deviations,
+    enrich_with_genre_stats,
+    find_genre_outliers,
+    popularity_by_feature_buckets,
+    run_analysis,
+)
+
+
+def make_row(**overrides: Any) -> dict[str, Any]:
+    """Build a single track row with sensible defaults."""
+
+    row = {
+        "track_id": "track-1",
+        "track_name": "Song 1",
+        "artists": "Artist 1",
+        "track_genre": "pop",
+        "popularity": 50,
+        "danceability": 0.5,
+        "energy": 0.7,
+        "loudness": -5.0,
+        "speechiness": 0.05,
+        "acousticness": 0.2,
+        "instrumentalness": 0.0,
+        "liveness": 0.1,
+        "valence": 0.6,
+        "tempo": 120.0,
+    }
+    row.update(overrides)
+    return row
+
+
+def make_df() -> pd.DataFrame:
+    """Return a small multi-genre DataFrame for analysis tests."""
+
+    return pd.DataFrame([
+        # Pop: high danceability, high energy, high popularity
+        make_row(track_id="t1", track_genre="pop", popularity=80,
+                 danceability=0.8, energy=0.9, loudness=-3.0,
+                 speechiness=0.04, acousticness=0.1, valence=0.8,
+                 instrumentalness=0.0, liveness=0.12, tempo=128.0),
+        make_row(track_id="t2", track_genre="pop", popularity=70,
+                 danceability=0.7, energy=0.8, loudness=-4.0,
+                 speechiness=0.06, acousticness=0.15, valence=0.7,
+                 instrumentalness=0.01, liveness=0.1, tempo=122.0),
+        make_row(track_id="t3", track_genre="pop", popularity=60,
+                 danceability=0.6, energy=0.7, loudness=-5.0,
+                 speechiness=0.05, acousticness=0.2, valence=0.6,
+                 instrumentalness=0.0, liveness=0.15, tempo=118.0),
+        # Rock: medium danceability, medium energy, medium popularity
+        make_row(track_id="t4", track_genre="rock", popularity=50,
+                 danceability=0.4, energy=0.6, loudness=-6.0,
+                 speechiness=0.08, acousticness=0.25, valence=0.5,
+                 instrumentalness=0.02, liveness=0.2, tempo=130.0),
+        make_row(track_id="t5", track_genre="rock", popularity=40,
+                 danceability=0.3, energy=0.5, loudness=-7.0,
+                 speechiness=0.1, acousticness=0.3, valence=0.4,
+                 instrumentalness=0.05, liveness=0.25, tempo=135.0),
+        make_row(track_id="t6", track_genre="rock", popularity=45,
+                 danceability=0.35, energy=0.55, loudness=-6.5,
+                 speechiness=0.09, acousticness=0.28, valence=0.45,
+                 instrumentalness=0.03, liveness=0.22, tempo=132.0),
+        # Jazz: low danceability, low energy, low popularity
+        make_row(track_id="t7", track_genre="jazz", popularity=30,
+                 danceability=0.2, energy=0.3, loudness=-10.0,
+                 speechiness=0.03, acousticness=0.7, valence=0.3,
+                 instrumentalness=0.2, liveness=0.08, tempo=95.0),
+        make_row(track_id="t8", track_genre="jazz", popularity=35,
+                 danceability=0.25, energy=0.35, loudness=-9.0,
+                 speechiness=0.04, acousticness=0.65, valence=0.35,
+                 instrumentalness=0.15, liveness=0.09, tempo=100.0),
+    ])
+
+
+# ------------------------------------------------------------------
+# enrich_with_genre_stats
+# ------------------------------------------------------------------
+
+
+class TestEnrichWithGenreStats:
+    def test_adds_mean_and_std_columns(self) -> None:
+        enriched = enrich_with_genre_stats(make_df())
+
+        for feature in AUDIO_FEATURES:
+            assert f"{feature}_genre_mean" in enriched.columns
+            assert f"{feature}_genre_std" in enriched.columns
+
+    def test_preserves_original_columns(self) -> None:
+        df = make_df()
+        enriched = enrich_with_genre_stats(df)
+
+        for col in df.columns:
+            assert col in enriched.columns
+
+    def test_row_count_unchanged(self) -> None:
+        df = make_df()
+        enriched = enrich_with_genre_stats(df)
+
+        assert len(enriched) == len(df)
+
+    def test_genre_mean_is_correct(self) -> None:
+        enriched = enrich_with_genre_stats(make_df())
+
+        pop_rows = enriched[enriched["track_genre"] == "pop"]
+        expected = np.mean([0.8, 0.7, 0.6])
+        assert abs(pop_rows.iloc[0]["danceability_genre_mean"] - expected) < 1e-10
+
+    def test_tracks_in_same_genre_share_stats(self) -> None:
+        enriched = enrich_with_genre_stats(make_df())
+
+        pop_rows = enriched[enriched["track_genre"] == "pop"]
+        means = pop_rows["energy_genre_mean"].unique()
+        assert len(means) == 1
+
+
+# ------------------------------------------------------------------
+# compute_genre_deviations
+# ------------------------------------------------------------------
+
+
+class TestComputeGenreDeviations:
+    def test_adds_deviation_score(self) -> None:
+        result = compute_genre_deviations(make_df())
+
+        assert "genre_deviation_score" in result.columns
+
+    def test_adds_zscore_columns(self) -> None:
+        result = compute_genre_deviations(make_df())
+
+        for feature in AUDIO_FEATURES:
+            assert f"{feature}_zscore" in result.columns
+
+    def test_deviation_scores_are_non_negative(self) -> None:
+        result = compute_genre_deviations(make_df())
+
+        assert (result["genre_deviation_score"] >= 0).all()
+
+    def test_mean_track_has_low_deviation(self) -> None:
+        """A track whose features equal the genre mean should score ~0."""
+
+        df = pd.DataFrame([
+            make_row(track_id="a", track_genre="pop", danceability=0.5),
+            make_row(track_id="b", track_genre="pop", danceability=0.5),
+            make_row(track_id="c", track_genre="pop", danceability=0.5),
+        ])
+        result = compute_genre_deviations(df)
+
+        # All tracks are identical, so std=0 and z-scores are NaN,
+        # which makes the deviation score NaN. This is expected behavior
+        # for genres with zero variance.
+        assert result["genre_deviation_score"].isna().all()
+
+
+# ------------------------------------------------------------------
+# find_genre_outliers
+# ------------------------------------------------------------------
+
+
+class TestFindGenreOutliers:
+    def test_returns_expected_columns(self) -> None:
+        outliers = find_genre_outliers(make_df(), threshold=0.5)
+
+        expected = [
+            "track_id", "track_name", "artists", "track_genre",
+            "popularity", "genre_deviation_score",
+        ]
+        assert list(outliers.columns) == expected
+
+    def test_respects_top_n(self) -> None:
+        outliers = find_genre_outliers(make_df(), threshold=0.0, top_n=3)
+
+        assert len(outliers) <= 3
+
+    def test_sorted_descending(self) -> None:
+        outliers = find_genre_outliers(make_df(), threshold=0.0)
+
+        if len(outliers) > 1:
+            assert outliers["genre_deviation_score"].is_monotonic_decreasing
+
+    def test_high_threshold_returns_fewer_results(self) -> None:
+        low = find_genre_outliers(make_df(), threshold=0.5)
+        high = find_genre_outliers(make_df(), threshold=5.0)
+
+        assert len(high) <= len(low)
+
+
+# ------------------------------------------------------------------
+# analyze_popularity_correlations
+# ------------------------------------------------------------------
+
+
+class TestAnalyzePopularityCorrelations:
+    def test_returns_all_features(self) -> None:
+        result = analyze_popularity_correlations(make_df())
+
+        assert set(result["feature"]) == set(AUDIO_FEATURES)
+
+    def test_sorted_by_absolute_correlation(self) -> None:
+        result = analyze_popularity_correlations(make_df())
+
+        assert result["abs_correlation"].is_monotonic_decreasing
+
+    def test_correlations_in_valid_range(self) -> None:
+        result = analyze_popularity_correlations(make_df())
+
+        assert (result["correlation"].abs() <= 1.0).all()
+
+    def test_direction_matches_sign(self) -> None:
+        result = analyze_popularity_correlations(make_df())
+
+        for _, row in result.iterrows():
+            if row["correlation"] > 0:
+                assert row["direction"] == "positive"
+            else:
+                assert row["direction"] == "negative"
+
+    def test_strength_labels_are_valid(self) -> None:
+        result = analyze_popularity_correlations(make_df())
+
+        valid = {"strong", "moderate", "weak", "very weak"}
+        assert set(result["strength"]).issubset(valid)
+
+
+# ------------------------------------------------------------------
+# compare_genres
+# ------------------------------------------------------------------
+
+
+class TestCompareGenres:
+    def test_returns_correct_genres(self) -> None:
+        result = compare_genres(make_df(), top_n=3)
+
+        assert set(result["genre"]) == {"pop", "rock", "jazz"}
+
+    def test_track_counts_are_correct(self) -> None:
+        result = compare_genres(make_df(), top_n=3)
+
+        pop_row = result[result["genre"] == "pop"].iloc[0]
+        assert pop_row["track_count"] == 3
+
+        jazz_row = result[result["genre"] == "jazz"].iloc[0]
+        assert jazz_row["track_count"] == 2
+
+    def test_respects_top_n(self) -> None:
+        result = compare_genres(make_df(), top_n=2)
+
+        assert len(result) == 2
+
+    def test_avg_popularity_is_correct(self) -> None:
+        result = compare_genres(make_df(), top_n=3)
+
+        pop_row = result[result["genre"] == "pop"].iloc[0]
+        expected = np.mean([80, 70, 60])
+        assert abs(pop_row["avg_popularity"] - expected) < 0.15
+
+    def test_has_audio_feature_averages(self) -> None:
+        result = compare_genres(make_df(), top_n=3)
+
+        for feature in AUDIO_FEATURES:
+            assert f"avg_{feature}" in result.columns
+
+
+# ------------------------------------------------------------------
+# popularity_by_feature_buckets
+# ------------------------------------------------------------------
+
+
+class TestPopularityByFeatureBuckets:
+    def test_returns_correct_columns(self) -> None:
+        result = popularity_by_feature_buckets(make_df(), "danceability", 3)
+
+        assert "avg_popularity" in result.columns
+        assert "track_count" in result.columns
+
+    def test_bucket_count_matches(self) -> None:
+        result = popularity_by_feature_buckets(make_df(), "danceability", 3)
+
+        assert len(result) == 3
+
+    def test_total_tracks_preserved(self) -> None:
+        df = make_df()
+        result = popularity_by_feature_buckets(df, "danceability", 3)
+
+        assert result["track_count"].sum() == len(df)
+
+    def test_avg_popularity_in_valid_range(self) -> None:
+        result = popularity_by_feature_buckets(make_df(), "energy", 4)
+
+        valid_buckets = result[result["track_count"] > 0]
+        assert (valid_buckets["avg_popularity"] >= 0).all()
+        assert (valid_buckets["avg_popularity"] <= 100).all()
+
+
+# ------------------------------------------------------------------
+# run_analysis
+# ------------------------------------------------------------------
+
+
+class TestRunAnalysis:
+    def test_returns_all_sections(self) -> None:
+        results = run_analysis(make_df())
+
+        assert "correlations" in results
+        assert "genre_comparison" in results
+        assert "genre_outliers" in results
+        assert "enriched_data" in results
+        assert "feature_buckets" in results
+
+    def test_feature_buckets_for_top_features(self) -> None:
+        results = run_analysis(make_df())
+
+        assert len(results["feature_buckets"]) <= 3
+        assert len(results["feature_buckets"]) > 0
+
+    def test_enriched_data_has_genre_stats(self) -> None:
+        results = run_analysis(make_df())
+        enriched = results["enriched_data"]
+
+        assert "danceability_genre_mean" in enriched.columns


### PR DESCRIPTION
## Summary
- New `analysis.py` module that answers our three research questions:
  - Q1: Feature-popularity correlations using `np.corrcoef` with strength classification
  - Q2: Genre comparison by average audio profiles using numpy array operations
  - Q3: Genre outlier detection by merging genre-level stats back onto tracks (`pd.merge` + `pd.concat`) and computing z-scores
- Includes `popularity_by_feature_buckets()` for non-linear pattern detection using `np.linspace`
- Added `demo_analysis.py` script that cleans the data and prints formatted findings
- 31 new tests in `test_analysis.py` covering all functions
- Updated README with research questions, analysis docs, and project structure
- Exported `run_analysis` from `__init__.py`

## Test plan
- [x] All 128 tests pass
- [x] `demo_analysis.py` runs against the real dataset and prints results
- [x] Verify output looks correct for each research question