### PR TITLE
Fix coerce_numeric_columns test dtype warning (#28)

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -120,6 +120,8 @@ def test_coerce_numeric_columns_counts_values_converted_to_missing() -> None:
     """Non-numeric strings should become missing in numeric columns."""
 
     df = make_valid_df()
+    df["tempo"] = df["tempo"].astype(object)
+    df["popularity"] = df["popularity"].astype(object)
     df.loc[0, "tempo"] = "fast"
     df.loc[1, "popularity"] = "very popular"
 


### PR DESCRIPTION
## Summary
Fixes #28. The test was triggering a pandas `FutureWarning` about assigning incompatible string values (`"fast"`, `"very popular"`) to columns typed as `float64`/`int64`. In a future pandas version this will become a hard `TypeError`.

The fix casts `tempo` and `popularity` to `object` dtype before the string assignment, so pandas accepts the values. The function under test (`coerce_numeric_columns`) then converts them to `NaN` as expected.

## Test plan
- [ ] Run `python -m pytest tests/test_clean.py -v` — all 10 tests pass
- [ ] Confirm no more `FutureWarning` about dtype incompatibility