### PR TITLE
Add hit shape predictor module with predictive modeling and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Thumbs.db
 # IDE settings
 .vscode/
 .idea/
+
+# Outputs
+outputs/

--- a/src/unwrapped/hit_shape_predictor.py
+++ b/src/unwrapped/hit_shape_predictor.py
@@ -1,0 +1,471 @@
+"""
+Hit shape predictor module for identifying whether a Spotify track
+resembles the profile of a hit song.
+
+This module defines a hit using a popularity threshold, builds average
+audio-feature profiles for hit and non-hit songs, computes similarity-
+based features, trains classification models, and reports performance.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
+from sklearn.model_selection import train_test_split, cross_val_score
+
+from .io import load_data
+
+
+REQUIRED_COLUMNS = [
+    "popularity",
+    "duration_ms",
+    "explicit",
+    "danceability",
+    "energy",
+    "key",
+    "loudness",
+    "mode",
+    "speechiness",
+    "acousticness",
+    "instrumentalness",
+    "liveness",
+    "valence",
+    "tempo",
+    "time_signature",
+]
+
+
+AUDIO_FEATURE_COLUMNS = [
+    "duration_ms",
+    "explicit",
+    "danceability",
+    "energy",
+    "key",
+    "loudness",
+    "mode",
+    "speechiness",
+    "acousticness",
+    "instrumentalness",
+    "liveness",
+    "valence",
+    "tempo",
+    "time_signature",
+]
+
+
+def validate_data(df):
+    """Validate that the dataframe is not empty and contains needed columns."""
+    if df.empty:
+        raise ValueError("Input dataframe is empty.")
+
+    missing_columns = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing_columns:
+        raise ValueError(
+            f"Missing required columns: {', '.join(missing_columns)}"
+        )
+
+
+def handle_missing_values(df):
+    """Handle missing values in popularity and predictor columns."""
+    df = df.copy()
+
+    df = df.dropna(subset=["popularity"])
+
+    if "explicit" in df.columns:
+        df["explicit"] = df["explicit"].fillna(False)
+
+    numeric_cols = df.select_dtypes(include=["number", "bool"]).columns.tolist()
+    numeric_feature_cols = [col for col in numeric_cols if col != "popularity"]
+
+    for col in numeric_feature_cols:
+        if col == "explicit":
+            continue
+        df[col] = df[col].fillna(df[col].median())
+
+    return df
+
+
+def preprocess_data(df):
+    """Drop non-modeling identifier/text columns and standardize booleans."""
+    df = df.copy()
+
+    cols_to_drop = [
+        "Unnamed: 0",
+        "track_id",
+        "artists",
+        "album_name",
+        "track_name",
+        "track_genre",
+    ]
+
+    df = df.drop(columns=cols_to_drop, errors="ignore")
+
+    if "explicit" in df.columns:
+        df["explicit"] = df["explicit"].astype(int)
+
+    return df
+
+
+def create_hit_label(df, threshold=70):
+    """Create a binary hit column using a popularity threshold."""
+    df = df.copy()
+    df["is_hit"] = (df["popularity"] >= threshold).astype(int)
+    return df
+
+
+def get_audio_feature_columns():
+    """Return the list of audio feature columns used in the model."""
+    return AUDIO_FEATURE_COLUMNS.copy()
+
+
+def build_hit_profiles(df):
+    """
+    Build average audio-feature profiles for hit and non-hit songs.
+
+    Returns a dataframe indexed by hit label:
+    - 0 = non-hit profile
+    - 1 = hit profile
+    """
+    feature_cols = get_audio_feature_columns()
+
+    profiles = (
+        df.groupby("is_hit")[feature_cols]
+        .mean()
+        .sort_index()
+    )
+
+    if profiles.shape[0] < 2:
+        raise ValueError("Both hit and non-hit groups are required to build profiles.")
+
+    return profiles
+
+
+def calculate_profile_differences(profiles):
+    """Calculate hit minus non-hit feature differences."""
+    if 0 not in profiles.index or 1 not in profiles.index:
+        raise ValueError("Profiles must contain both non-hit (0) and hit (1).")
+
+    difference_df = pd.DataFrame({
+        "feature": profiles.columns,
+        "non_hit_mean": profiles.loc[0].values,
+        "hit_mean": profiles.loc[1].values,
+        "difference_hit_minus_non_hit": (
+            profiles.loc[1].values - profiles.loc[0].values
+        )
+    })
+
+    difference_df["absolute_difference"] = (
+        difference_df["difference_hit_minus_non_hit"].abs()
+    )
+
+    difference_df = difference_df.sort_values(
+        by="absolute_difference",
+        ascending=False
+    ).reset_index(drop=True)
+
+    return difference_df
+
+
+def compute_centroids(df):
+    """Return the non-hit centroid and hit centroid as numpy arrays."""
+    profiles = build_hit_profiles(df)
+    non_hit_centroid = profiles.loc[0].to_numpy()
+    hit_centroid = profiles.loc[1].to_numpy()
+    return non_hit_centroid, hit_centroid
+
+
+def compute_similarity_features(df):
+    """
+    Compute engineered similarity features based on distance to
+    hit and non-hit audio profiles.
+    """
+    df = df.copy()
+    feature_cols = get_audio_feature_columns()
+
+    non_hit_centroid, hit_centroid = compute_centroids(df)
+    X = df[feature_cols].to_numpy()
+
+    distance_to_non_hit = np.linalg.norm(X - non_hit_centroid, axis=1)
+    distance_to_hit = np.linalg.norm(X - hit_centroid, axis=1)
+
+    df["distance_to_non_hit"] = distance_to_non_hit
+    df["distance_to_hit"] = distance_to_hit
+    df["hit_distance_advantage"] = distance_to_non_hit - distance_to_hit
+    df["hit_closeness_ratio"] = distance_to_hit / (distance_to_non_hit + 1e-9)
+
+    return df
+
+
+def build_modeling_dataframe(df):
+    """Build the final modeling dataframe using engineered similarity features."""
+    df = df.copy()
+
+    model_df = df[
+        [
+            "distance_to_non_hit",
+            "distance_to_hit",
+            "hit_distance_advantage",
+            "hit_closeness_ratio",
+            "is_hit",
+        ]
+    ].copy()
+
+    return model_df
+
+
+def split_data(df, test_size=0.2, random_state=42):
+    """Split similarity-feature data into train and test sets."""
+    X = df.drop(columns=["is_hit"])
+    y = df["is_hit"]
+
+    return train_test_split(
+        X,
+        y,
+        test_size=test_size,
+        random_state=random_state,
+        stratify=y
+    )
+
+
+def train_logistic_model(X_train, y_train):
+    """Train a logistic regression classifier."""
+    model = LogisticRegression(
+        max_iter=1000,
+        random_state=42,
+        class_weight="balanced"
+    )
+    model.fit(X_train, y_train)
+    return model
+
+
+def train_random_forest(X_train, y_train):
+    """Train a random forest classifier."""
+    model = RandomForestClassifier(
+        n_estimators=300,
+        max_depth=None,
+        max_features="sqrt",
+        min_samples_split=2,
+        min_samples_leaf=1,
+        random_state=42,
+        n_jobs=-1
+    )
+    model.fit(X_train, y_train)
+    return model
+
+
+def evaluate_model(model, X_test, y_test, model_name="Model"):
+    """Evaluate classifier performance using several classification metrics."""
+    predictions = model.predict(X_test)
+
+    accuracy = accuracy_score(y_test, predictions)
+    precision = precision_score(y_test, predictions, zero_division=0)
+    recall = recall_score(y_test, predictions, zero_division=0)
+    f1 = f1_score(y_test, predictions, zero_division=0)
+
+    print(f"{model_name} Accuracy: {accuracy:.4f}")
+    print(f"{model_name} Precision: {precision:.4f}")
+    print(f"{model_name} Recall: {recall:.4f}")
+    print(f"{model_name} F1: {f1:.4f}")
+
+    return {
+        "model": model_name,
+        "accuracy": accuracy,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }
+
+
+def cross_validate_model(model, X_train, y_train, cv=5):
+    """Cross-validate a model using accuracy and F1."""
+    accuracy_scores = cross_val_score(
+        model,
+        X_train,
+        y_train,
+        cv=cv,
+        scoring="accuracy",
+        n_jobs=-1
+    )
+
+    f1_scores = cross_val_score(
+        model,
+        X_train,
+        y_train,
+        cv=cv,
+        scoring="f1",
+        n_jobs=-1
+    )
+
+    return {
+        "cv_accuracy_mean": accuracy_scores.mean(),
+        "cv_accuracy_std": accuracy_scores.std(),
+        "cv_f1_mean": f1_scores.mean(),
+    }
+
+
+def compare_models(results):
+    """Create a comparison dataframe for trained models."""
+    comparison_df = pd.DataFrame(results)
+    numeric_cols = comparison_df.select_dtypes(include=["number"]).columns
+
+    for col in numeric_cols:
+        comparison_df[col] = comparison_df[col].round(4)
+
+    comparison_df = comparison_df.sort_values(
+        by="f1",
+        ascending=False
+    ).reset_index(drop=True)
+
+    print("\nModel Comparison:")
+    print(comparison_df.to_string(index=False))
+
+    return comparison_df
+
+
+def get_feature_importance(model, X_train):
+    """Return feature importances from the random forest classifier."""
+    importance_df = pd.DataFrame({
+        "feature": X_train.columns,
+        "importance": model.feature_importances_
+    })
+
+    importance_df = importance_df.sort_values(
+        by="importance",
+        ascending=False
+    ).reset_index(drop=True)
+
+    print("\nSimilarity Feature Importances:")
+    print(importance_df.to_string(index=False))
+
+    return importance_df
+
+
+def build_predictions_df(model, X_test, y_test):
+    """Build a dataframe of actual vs predicted hit labels."""
+    predictions = model.predict(X_test)
+
+    predictions_df = pd.DataFrame({
+        "actual_is_hit": y_test.values,
+        "predicted_is_hit": predictions,
+    })
+
+    return predictions_df
+
+
+def save_outputs(
+    profiles_df,
+    differences_df,
+    comparison_df,
+    importance_df,
+    predictions_df,
+    output_dir="outputs"
+):
+    """Save output tables as CSV files."""
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    profiles_df.to_csv(output_path / "hit_shape_profiles.csv")
+    differences_df.to_csv(output_path / "hit_shape_profile_differences.csv", index=False)
+    comparison_df.to_csv(output_path / "hit_shape_model_comparison.csv", index=False)
+    importance_df.to_csv(output_path / "hit_shape_similarity_importance.csv", index=False)
+    predictions_df.to_csv(output_path / "hit_shape_predictions.csv", index=False)
+
+
+def run_hit_shape_pipeline(
+    data_path="data/raw/spotify_data.csv",
+    hit_threshold=70,
+    save_results=True
+):
+    """Run the full hit shape prediction pipeline."""
+    df = load_data(data_path)
+
+    validate_data(df)
+    df = handle_missing_values(df)
+    df = preprocess_data(df)
+    df = create_hit_label(df, threshold=hit_threshold)
+
+    profiles_df = build_hit_profiles(df)
+    differences_df = calculate_profile_differences(profiles_df)
+
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+
+    X_train, X_test, y_train, y_test = split_data(model_df)
+
+    logistic_model = train_logistic_model(X_train, y_train)
+    logistic_results = evaluate_model(
+        logistic_model,
+        X_test,
+        y_test,
+        "Logistic Regression"
+    )
+    logistic_results.update(
+        cross_validate_model(
+            LogisticRegression(
+                max_iter=1000,
+                random_state=42,
+                class_weight="balanced"
+            ),
+            X_train,
+            y_train
+        )
+    )
+
+    random_forest_model = train_random_forest(X_train, y_train)
+    rf_results = evaluate_model(
+        random_forest_model,
+        X_test,
+        y_test,
+        "Random Forest"
+    )
+    rf_results.update(
+        cross_validate_model(
+            RandomForestClassifier(
+                n_estimators=300,
+                max_depth=None,
+                max_features="sqrt",
+                min_samples_split=2,
+                min_samples_leaf=1,
+                random_state=42,
+                n_jobs=-1
+            ),
+            X_train,
+            y_train
+        )
+    )
+
+    comparison_df = compare_models([logistic_results, rf_results])
+    importance_df = get_feature_importance(random_forest_model, X_train)
+    predictions_df = build_predictions_df(random_forest_model, X_test, y_test)
+
+    if save_results:
+        save_outputs(
+            profiles_df,
+            differences_df,
+            comparison_df,
+            importance_df,
+            predictions_df
+        )
+
+    return {
+        "profiles": profiles_df,
+        "differences": differences_df,
+        "comparison": comparison_df,
+        "feature_importance": importance_df,
+        "predictions": predictions_df,
+        "logistic_model": logistic_model,
+        "random_forest_model": random_forest_model,
+    }
+
+
+def main():
+    """Run the default hit shape pipeline."""
+    run_hit_shape_pipeline("data/raw/spotify_data.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hit_shape_predictor.py
+++ b/tests/test_hit_shape_predictor.py
@@ -1,0 +1,269 @@
+import pandas as pd
+import pytest
+
+from unwrapped.hit_shape_predictor import (
+    validate_data,
+    handle_missing_values,
+    preprocess_data,
+    create_hit_label,
+    build_hit_profiles,
+    calculate_profile_differences,
+    compute_similarity_features,
+    build_modeling_dataframe,
+    split_data,
+    train_logistic_model,
+    train_random_forest,
+    evaluate_model,
+    compare_models,
+    build_predictions_df,
+)
+
+
+def make_sample_df():
+    """Create a small dataframe that mimics the Spotify dataset."""
+    data = {
+        "Unnamed: 0": [0, 1, 2, 3, 4, 5, 6, 7],
+        "track_id": ["a", "b", "c", "d", "e", "f", "g", "h"],
+        "artists": ["x", "y", "z", "w", "p", "q", "r", "s"],
+        "album_name": ["al1", "al2", "al3", "al4", "al5", "al6", "al7", "al8"],
+        "track_name": ["t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8"],
+        "track_genre": ["pop", "pop", "rock", "rock", "hip-hop", "jazz", "pop", "rock"],
+        "popularity": [80, 75, 20, 30, 90, 15, 68, 72],
+        "duration_ms": [200000, 210000, 180000, 190000, 220000, 175000, 205000, 215000],
+        "explicit": [0, 0, 1, 0, 1, 0, 0, 1],
+        "danceability": [0.70, 0.65, 0.40, 0.45, 0.75, 0.35, 0.62, 0.68],
+        "energy": [0.80, 0.75, 0.50, 0.55, 0.85, 0.45, 0.70, 0.78],
+        "key": [5, 6, 4, 3, 7, 2, 5, 6],
+        "loudness": [-5, -6, -10, -9, -4, -11, -7, -5],
+        "mode": [1, 1, 0, 1, 1, 0, 1, 1],
+        "speechiness": [0.05, 0.06, 0.04, 0.03, 0.07, 0.02, 0.05, 0.06],
+        "acousticness": [0.10, 0.15, 0.60, 0.50, 0.08, 0.70, 0.20, 0.12],
+        "instrumentalness": [0.00, 0.00, 0.20, 0.30, 0.00, 0.35, 0.05, 0.01],
+        "liveness": [0.10, 0.12, 0.20, 0.18, 0.11, 0.25, 0.14, 0.13],
+        "valence": [0.60, 0.65, 0.40, 0.35, 0.72, 0.30, 0.58, 0.66],
+        "tempo": [120, 118, 100, 105, 125, 95, 116, 121],
+        "time_signature": [4, 4, 4, 4, 4, 4, 4, 4],
+    }
+    return pd.DataFrame(data)
+
+
+def prepare_df():
+    df = make_sample_df()
+    validate_data(df)
+    df = handle_missing_values(df)
+    df = preprocess_data(df)
+    df = create_hit_label(df, threshold=70)
+    return df
+
+
+def test_validate_data_passes_with_valid_dataframe():
+    df = make_sample_df()
+    validate_data(df)
+
+
+def test_validate_data_raises_for_empty_dataframe():
+    df = pd.DataFrame()
+    with pytest.raises(ValueError):
+        validate_data(df)
+
+
+def test_validate_data_raises_for_missing_required_column():
+    df = make_sample_df().drop(columns=["tempo"])
+    with pytest.raises(ValueError):
+        validate_data(df)
+
+
+def test_handle_missing_values_drops_missing_popularity():
+    df = make_sample_df()
+    df.loc[0, "popularity"] = None
+
+    cleaned = handle_missing_values(df)
+
+    assert len(cleaned) == 7
+    assert cleaned["popularity"].isna().sum() == 0
+
+
+def test_handle_missing_values_fills_numeric_missing_values():
+    df = make_sample_df()
+    df.loc[0, "danceability"] = None
+    df.loc[1, "energy"] = None
+
+    cleaned = handle_missing_values(df)
+
+    assert cleaned["danceability"].isna().sum() == 0
+    assert cleaned["energy"].isna().sum() == 0
+
+
+def test_preprocess_data_drops_unused_columns():
+    df = make_sample_df()
+    processed = preprocess_data(df)
+
+    assert "Unnamed: 0" not in processed.columns
+    assert "track_id" not in processed.columns
+    assert "artists" not in processed.columns
+    assert "album_name" not in processed.columns
+    assert "track_name" not in processed.columns
+    assert "track_genre" not in processed.columns
+
+
+def test_create_hit_label_adds_binary_column():
+    df = preprocess_data(handle_missing_values(make_sample_df()))
+    df = create_hit_label(df, threshold=70)
+
+    assert "is_hit" in df.columns
+    assert set(df["is_hit"].unique()) == {0, 1}
+
+
+def test_create_hit_label_counts_hits_correctly():
+    df = preprocess_data(handle_missing_values(make_sample_df()))
+    df = create_hit_label(df, threshold=70)
+
+    assert df["is_hit"].sum() == 4
+
+
+def test_build_hit_profiles_returns_two_groups():
+    df = prepare_df()
+    profiles = build_hit_profiles(df)
+
+    assert profiles.shape[0] == 2
+    assert 0 in profiles.index
+    assert 1 in profiles.index
+
+
+def test_build_hit_profiles_contains_expected_features():
+    df = prepare_df()
+    profiles = build_hit_profiles(df)
+
+    assert "danceability" in profiles.columns
+    assert "energy" in profiles.columns
+    assert "tempo" in profiles.columns
+
+
+def test_build_hit_profiles_raises_if_only_one_class_present():
+    df = prepare_df()
+    df["is_hit"] = 1
+
+    with pytest.raises(ValueError):
+        build_hit_profiles(df)
+
+
+def test_calculate_profile_differences_returns_expected_columns():
+    df = prepare_df()
+    profiles = build_hit_profiles(df)
+    diff_df = calculate_profile_differences(profiles)
+
+    assert "feature" in diff_df.columns
+    assert "non_hit_mean" in diff_df.columns
+    assert "hit_mean" in diff_df.columns
+    assert "difference_hit_minus_non_hit" in diff_df.columns
+    assert "absolute_difference" in diff_df.columns
+
+
+def test_compute_similarity_features_adds_engineered_columns():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+
+    assert "distance_to_non_hit" in similarity_df.columns
+    assert "distance_to_hit" in similarity_df.columns
+    assert "hit_distance_advantage" in similarity_df.columns
+    assert "hit_closeness_ratio" in similarity_df.columns
+
+
+def test_build_modeling_dataframe_has_expected_columns_only():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+
+    expected_columns = {
+        "distance_to_non_hit",
+        "distance_to_hit",
+        "hit_distance_advantage",
+        "hit_closeness_ratio",
+        "is_hit",
+    }
+
+    assert set(model_df.columns) == expected_columns
+
+
+def test_split_data_returns_nonempty_sets():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+
+    X_train, X_test, y_train, y_test = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    assert len(X_train) > 0
+    assert len(X_test) > 0
+    assert len(y_train) > 0
+    assert len(y_test) > 0
+
+
+def test_train_logistic_model_has_predict_method():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, X_test, y_train, y_test = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    model = train_logistic_model(X_train, y_train)
+    assert hasattr(model, "predict")
+
+
+def test_train_random_forest_has_feature_importances():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, X_test, y_train, y_test = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    model = train_random_forest(X_train, y_train)
+    assert hasattr(model, "feature_importances_")
+
+
+def test_evaluate_model_returns_expected_metric_keys():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, X_test, y_train, y_test = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    model = train_logistic_model(X_train, y_train)
+    results = evaluate_model(model, X_test, y_test, "Logistic Regression")
+
+    assert "model" in results
+    assert "accuracy" in results
+    assert "precision" in results
+    assert "recall" in results
+    assert "f1" in results
+
+
+def test_compare_models_sorts_highest_f1_first():
+    results = [
+        {"model": "A", "accuracy": 0.80, "precision": 0.70, "recall": 0.60, "f1": 0.65},
+        {"model": "B", "accuracy": 0.82, "precision": 0.75, "recall": 0.70, "f1": 0.72},
+    ]
+
+    comparison = compare_models(results)
+
+    assert comparison.iloc[0]["model"] == "B"
+
+
+def test_build_predictions_df_has_expected_columns():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, X_test, y_train, y_test = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    model = train_random_forest(X_train, y_train)
+    predictions_df = build_predictions_df(model, X_test, y_test)
+
+    assert "actual_is_hit" in predictions_df.columns
+    assert "predicted_is_hit" in predictions_df.columns
+    assert len(predictions_df) == len(y_test)


### PR DESCRIPTION
This PR adds a hit shape predictor module to support predictive modeling for Spotify song success.

The module identifies the "shape" of a hit song by building average audio-feature profiles for hit and non-hit tracks and engineering similarity features.

Key features:
- Hit vs non-hit profile construction
- Similarity-based feature engineering
- Logistic Regression and Random Forest classifiers
- Model evaluation (accuracy, precision, recall, F1)
- Cross-validation for robustness
- Exportable output tables for analysis and visualization

Additional improvements:
- Comprehensive pytest test suite (20 tests)
- Edge case coverage for data validation and model functions
- outputs/ directory added to .gitignore

This feature supports the research questions:
- What audio features best predict song popularity?
- Do popular songs converge toward a similar sound profile?
- What does the shape of a hit song look like?

All tests pass locally with pytest.