### PR TITLE
Fix repo review punch list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy>=2.0
+pandas>=2.2
+matplotlib>=3.8
+scikit-learn>=1.4
+
+# Dev / test
+pytest>=8.0

--- a/src/unwrapped/__init__.py
+++ b/src/unwrapped/__init__.py
@@ -3,14 +3,20 @@
 from .analysis import run_analysis
 from .clean import clean_data
 from .clean import run_cleaning
+from .constants import AUDIO_FEATURES
+from .popularity import run_popularity_pipeline
+from .preference import LikedSongs
 from .summary import run_summary
 from .summary import summarize_data
 from .validation import run_validation
 
 __all__ = [
+    "AUDIO_FEATURES",
+    "LikedSongs",
     "clean_data",
     "run_analysis",
     "run_cleaning",
+    "run_popularity_pipeline",
     "run_summary",
     "run_validation",
     "summarize_data",

--- a/src/unwrapped/analysis.py
+++ b/src/unwrapped/analysis.py
@@ -16,19 +16,8 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from .constants import AUDIO_FEATURES
 from .io import load_data
-
-AUDIO_FEATURES = [
-    "danceability",
-    "energy",
-    "loudness",
-    "speechiness",
-    "acousticness",
-    "instrumentalness",
-    "liveness",
-    "valence",
-    "tempo",
-]
 
 
 # ---------------------------------------------------------------------------
@@ -114,10 +103,16 @@ def compute_genre_deviations(df: pd.DataFrame) -> pd.DataFrame:
         safe_stds = np.where(stds > 0, stds, np.nan)
         z_scores[:, i] = (values - means) / safe_stds
 
-    # Overall deviation = mean absolute z-score across all features
-    enriched["genre_deviation_score"] = np.round(
-        np.nanmean(np.abs(z_scores), axis=1), 4
-    )
+    # Overall deviation = mean absolute z-score across all features.
+    # Tracks in single-track genres have all-NaN z-score rows (std is 0),
+    # so compute nanmean only for rows that have at least one valid value
+    # and leave the rest as NaN — avoids a "Mean of empty slice" warning.
+    abs_z = np.abs(z_scores)
+    has_valid = ~np.all(np.isnan(abs_z), axis=1)
+    deviation = np.full(len(enriched), np.nan)
+    if has_valid.any():
+        deviation[has_valid] = np.nanmean(abs_z[has_valid], axis=1)
+    enriched["genre_deviation_score"] = np.round(deviation, 4)
 
     for i, feature in enumerate(AUDIO_FEATURES):
         enriched[f"{feature}_zscore"] = np.round(z_scores[:, i], 4)
@@ -300,6 +295,16 @@ def popularity_by_feature_buckets(
     pd.DataFrame
         One row per bucket with ``avg_popularity`` and ``track_count``.
     """
+
+    if feature not in df.columns:
+        raise ValueError(
+            f"feature '{feature}' not in DataFrame. "
+            f"Available columns: {sorted(df.columns.tolist())}"
+        )
+    if "popularity" not in df.columns:
+        raise ValueError("DataFrame must contain a 'popularity' column.")
+    if n_buckets < 1:
+        raise ValueError(f"n_buckets must be >= 1, got {n_buckets}")
 
     tmp = df[[feature, "popularity"]].dropna().copy()
     values = tmp[feature].values.astype(float)

--- a/src/unwrapped/constants.py
+++ b/src/unwrapped/constants.py
@@ -1,0 +1,15 @@
+"""Shared constants for the unwrapped package."""
+
+from __future__ import annotations
+
+AUDIO_FEATURES: list[str] = [
+    "danceability",
+    "energy",
+    "loudness",
+    "speechiness",
+    "acousticness",
+    "instrumentalness",
+    "liveness",
+    "valence",
+    "tempo",
+]

--- a/src/unwrapped/popularity.py
+++ b/src/unwrapped/popularity.py
@@ -1,25 +1,28 @@
-"""
-Popularity regression module for predicting Spotify track popularity
-using audio features and metadata.
+"""Popularity regression module for predicting Spotify track popularity.
 
-This module validates the input data, handles missing values, compares
-a baseline linear regression model to a random forest regressor, reports
+This module validates the input data, handles missing values, compares a
+baseline linear regression model to a random forest regressor, reports
 feature importance, and optionally saves outputs for downstream use.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 
-from sklearn.model_selection import train_test_split, cross_val_score
-from sklearn.linear_model import LinearRegression
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import cross_val_score, train_test_split
 
 from .io import load_data
 
 
-REQUIRED_COLUMNS = [
+DEFAULT_OUTPUT_DIR = "outputs"
+
+REQUIRED_COLUMNS: list[str] = [
     "popularity",
     "track_genre",
     "duration_ms",
@@ -31,11 +34,23 @@ REQUIRED_COLUMNS = [
     "instrumentalness",
     "liveness",
     "valence",
-    "tempo"
+    "tempo",
 ]
 
 
-def validate_data(df):
+def validate_data(df: pd.DataFrame) -> None:
+    """Check that ``df`` is non-empty and contains all required columns.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Raw Spotify dataset to validate.
+
+    Raises
+    ------
+    ValueError
+        If ``df`` is empty or is missing any column in :data:`REQUIRED_COLUMNS`.
+    """
     if df.empty:
         raise ValueError("Input dataframe is empty.")
 
@@ -46,7 +61,23 @@ def validate_data(df):
         )
 
 
-def handle_missing_values(df):
+def handle_missing_values(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop rows without a popularity target and impute the rest.
+
+    Rows missing the ``popularity`` target are dropped. Missing
+    ``track_genre`` values are replaced with ``"unknown"``. Numeric
+    feature columns are filled with their median.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Validated dataset.
+
+    Returns
+    -------
+    pd.DataFrame
+        Copy of ``df`` with missing values handled.
+    """
     df = df.copy()
 
     df = df.dropna(subset=["popularity"])
@@ -61,7 +92,19 @@ def handle_missing_values(df):
     return df
 
 
-def preprocess_data(df):
+def preprocess_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop identifier columns and one-hot encode ``track_genre``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataset already passed through :func:`handle_missing_values`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Model-ready feature frame.
+    """
     df = df.copy()
 
     cols_to_drop = [
@@ -69,7 +112,7 @@ def preprocess_data(df):
         "track_name",
         "album_name",
         "artists",
-        "Unnamed: 0"
+        "Unnamed: 0",
     ]
 
     df = df.drop(columns=cols_to_drop, errors="ignore")
@@ -78,7 +121,27 @@ def preprocess_data(df):
     return df
 
 
-def split_data(df, test_size=0.2, random_state=42):
+def split_data(
+    df: pd.DataFrame,
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
+    """Split ``df`` into train/test feature matrices and popularity targets.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Preprocessed dataset containing a ``popularity`` column.
+    test_size : float, default 0.2
+        Fraction of rows held out for testing.
+    random_state : int, default 42
+        Seed passed to ``train_test_split`` for reproducibility.
+
+    Returns
+    -------
+    tuple
+        ``(X_train, X_test, y_train, y_test)``.
+    """
     X = df.drop(columns=["popularity"])
     y = df["popularity"]
 
@@ -87,13 +150,17 @@ def split_data(df, test_size=0.2, random_state=42):
     )
 
 
-def train_linear_model(X_train, y_train):
+def train_linear_model(X_train: pd.DataFrame, y_train: pd.Series) -> LinearRegression:
+    """Fit a baseline linear regression on the training set."""
     model = LinearRegression()
     model.fit(X_train, y_train)
     return model
 
 
-def train_random_forest(X_train, y_train):
+def train_random_forest(
+    X_train: pd.DataFrame, y_train: pd.Series
+) -> RandomForestRegressor:
+    """Fit a tuned random forest regressor on the training set."""
     model = RandomForestRegressor(
         n_estimators=300,
         max_depth=None,
@@ -101,13 +168,34 @@ def train_random_forest(X_train, y_train):
         min_samples_split=2,
         min_samples_leaf=1,
         random_state=42,
-        n_jobs=-1
+        n_jobs=-1,
     )
     model.fit(X_train, y_train)
     return model
 
 
-def evaluate_model(model, X_test, y_test, model_name="Model"):
+def evaluate_model(
+    model: Any,
+    X_test: pd.DataFrame,
+    y_test: pd.Series,
+    model_name: str = "Model",
+) -> dict[str, Any]:
+    """Score ``model`` on the held-out test set and print a short report.
+
+    Parameters
+    ----------
+    model : Any
+        Fitted scikit-learn estimator exposing ``.predict``.
+    X_test, y_test :
+        Held-out features and target.
+    model_name : str
+        Label used in the printed report.
+
+    Returns
+    -------
+    dict
+        ``{"model", "rmse", "mae", "r2"}`` for downstream comparison.
+    """
     predictions = model.predict(X_test)
 
     mse = mean_squared_error(y_test, predictions)
@@ -123,18 +211,39 @@ def evaluate_model(model, X_test, y_test, model_name="Model"):
         "model": model_name,
         "rmse": rmse,
         "mae": mae,
-        "r2": r2
+        "r2": r2,
     }
 
 
-def cross_validate_model(model, X_train, y_train, cv=5):
+def cross_validate_model(
+    model: Any,
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    cv: int = 5,
+) -> dict[str, float]:
+    """Run k-fold cross-validation and return RMSE and R^2 summaries.
+
+    Parameters
+    ----------
+    model : Any
+        Unfitted scikit-learn estimator.
+    X_train, y_train :
+        Training split used for cross-validation.
+    cv : int, default 5
+        Number of folds.
+
+    Returns
+    -------
+    dict
+        ``cv_rmse_mean``, ``cv_rmse_std``, and ``cv_r2_mean``.
+    """
     neg_rmse_scores = cross_val_score(
         model,
         X_train,
         y_train,
         cv=cv,
         scoring="neg_root_mean_squared_error",
-        n_jobs=-1
+        n_jobs=-1,
     )
 
     r2_scores = cross_val_score(
@@ -143,7 +252,7 @@ def cross_validate_model(model, X_train, y_train, cv=5):
         y_train,
         cv=cv,
         scoring="r2",
-        n_jobs=-1
+        n_jobs=-1,
     )
 
     cv_rmse_mean = -neg_rmse_scores.mean()
@@ -153,11 +262,12 @@ def cross_validate_model(model, X_train, y_train, cv=5):
     return {
         "cv_rmse_mean": cv_rmse_mean,
         "cv_rmse_std": cv_rmse_std,
-        "cv_r2_mean": cv_r2_mean
+        "cv_r2_mean": cv_r2_mean,
     }
 
 
-def compare_models(results):
+def compare_models(results: list[dict[str, Any]]) -> pd.DataFrame:
+    """Combine per-model result dicts into a sorted comparison DataFrame."""
     comparison_df = pd.DataFrame(results)
     numeric_cols = comparison_df.select_dtypes(include=["number"]).columns
 
@@ -172,16 +282,22 @@ def compare_models(results):
     return comparison_df
 
 
-def get_feature_importance(model, X_train, top_n=10):
+def get_feature_importance(
+    model: RandomForestRegressor,
+    X_train: pd.DataFrame,
+    top_n: int = 10,
+) -> pd.DataFrame:
+    """Return the top ``top_n`` features ranked by ``feature_importances_``."""
     importances = pd.DataFrame({
         "feature": X_train.columns,
-        "importance": model.feature_importances_
+        "importance": model.feature_importances_,
     })
 
-    importances = importances.sort_values(
-        by="importance",
-        ascending=False
-    ).head(top_n).reset_index(drop=True)
+    importances = (
+        importances.sort_values(by="importance", ascending=False)
+        .head(top_n)
+        .reset_index(drop=True)
+    )
 
     print("\nTop Feature Importances:")
     print(importances.to_string(index=False))
@@ -189,16 +305,67 @@ def get_feature_importance(model, X_train, top_n=10):
     return importances
 
 
-def save_outputs(comparison_df, feature_importance_df, predictions_df, output_dir="outputs"):
+def save_outputs(
+    comparison_df: pd.DataFrame,
+    feature_importance_df: pd.DataFrame,
+    predictions_df: pd.DataFrame,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, str]:
+    """Write model comparison, feature importance, and predictions to CSV.
+
+    Parameters
+    ----------
+    comparison_df, feature_importance_df, predictions_df :
+        Artifacts produced by :func:`run_popularity_pipeline`.
+    output_dir : str | Path, default :data:`DEFAULT_OUTPUT_DIR`
+        Directory to write into; created if missing.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of artifact name to the path written.
+    """
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
-    comparison_df.to_csv(output_path / "popularity_model_comparison.csv", index=False)
-    feature_importance_df.to_csv(output_path / "popularity_feature_importance.csv", index=False)
-    predictions_df.to_csv(output_path / "popularity_predictions.csv", index=False)
+    comparison_path = output_path / "popularity_model_comparison.csv"
+    importance_path = output_path / "popularity_feature_importance.csv"
+    predictions_path = output_path / "popularity_predictions.csv"
+
+    comparison_df.to_csv(comparison_path, index=False)
+    feature_importance_df.to_csv(importance_path, index=False)
+    predictions_df.to_csv(predictions_path, index=False)
+
+    return {
+        "comparison": str(comparison_path),
+        "feature_importance": str(importance_path),
+        "predictions": str(predictions_path),
+    }
 
 
-def run_popularity_pipeline(data_path="data/raw/spotify_data.csv", save_results=True):
+def run_popularity_pipeline(
+    data_path: str = "data/raw/spotify_data.csv",
+    save_results: bool = True,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, Any]:
+    """Run the full popularity modeling pipeline end-to-end.
+
+    Parameters
+    ----------
+    data_path : str
+        CSV path passed to :func:`unwrapped.io.load_data`.
+    save_results : bool, default True
+        When ``True``, call :func:`save_outputs` to write CSVs.
+    output_dir : str | Path
+        Directory the CSV artifacts are written to when ``save_results``
+        is ``True``.
+
+    Returns
+    -------
+    dict
+        Fitted models, comparison frame, feature importances, and the
+        test-set predictions.
+    """
     df = load_data(data_path)
 
     validate_data(df)
@@ -212,7 +379,7 @@ def run_popularity_pipeline(data_path="data/raw/spotify_data.csv", save_results=
         linear_model,
         X_test,
         y_test,
-        "Linear Regression"
+        "Linear Regression",
     )
 
     linear_cv = cross_validate_model(LinearRegression(), X_train, y_train)
@@ -223,7 +390,7 @@ def run_popularity_pipeline(data_path="data/raw/spotify_data.csv", save_results=
         random_forest_model,
         X_test,
         y_test,
-        "Random Forest"
+        "Random Forest",
     )
 
     rf_cv = cross_validate_model(
@@ -234,10 +401,10 @@ def run_popularity_pipeline(data_path="data/raw/spotify_data.csv", save_results=
             min_samples_split=2,
             min_samples_leaf=1,
             random_state=42,
-            n_jobs=-1
+            n_jobs=-1,
         ),
         X_train,
-        y_train
+        y_train,
     )
     rf_results.update(rf_cv)
 
@@ -247,22 +414,27 @@ def run_popularity_pipeline(data_path="data/raw/spotify_data.csv", save_results=
     test_predictions = pd.DataFrame({
         "actual_popularity": y_test.values,
         "linear_prediction": linear_model.predict(X_test),
-        "random_forest_prediction": random_forest_model.predict(X_test)
+        "random_forest_prediction": random_forest_model.predict(X_test),
     })
 
     if save_results:
-        save_outputs(comparison_df, feature_importance_df, test_predictions)
+        save_outputs(
+            comparison_df,
+            feature_importance_df,
+            test_predictions,
+            output_dir=output_dir,
+        )
 
     return {
         "linear_model": linear_model,
         "random_forest_model": random_forest_model,
         "comparison": comparison_df,
         "feature_importance": feature_importance_df,
-        "predictions": test_predictions
+        "predictions": test_predictions,
     }
 
 
-def main():
+def main() -> None:
     run_popularity_pipeline("data/raw/spotify_data.csv")
 
 

--- a/src/unwrapped/preference.py
+++ b/src/unwrapped/preference.py
@@ -24,26 +24,13 @@ Example:
 """
 
 import json
+from pathlib import Path
 
 import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics.pairwise import cosine_similarity
 
-
-# The 9 continuous audio features used to build the taste profile.
-# These are kept as a module-level constant so other modules can import
-# and reuse the same feature set.
-AUDIO_FEATURES = [
-    "danceability",
-    "energy",
-    "loudness",
-    "speechiness",
-    "acousticness",
-    "instrumentalness",
-    "liveness",
-    "valence",
-    "tempo",
-]
+from .constants import AUDIO_FEATURES
 
 
 class LikedSongs:
@@ -236,7 +223,10 @@ class LikedSongs:
         feature_matrix = self.df[AUDIO_FEATURES].copy()
         feature_matrix_scaled = scaler.fit_transform(feature_matrix)
 
-        profile_scaled = scaler.transform(profile.values.reshape(1, -1))
+        # Wrap the profile as a DataFrame with matching column names so
+        # sklearn doesn't warn about the transformer losing feature names.
+        profile_df = profile.reindex(AUDIO_FEATURES).to_frame().T
+        profile_scaled = scaler.transform(profile_df)
 
         # Cosine similarity: shape is (n_songs, 1)
         similarities = cosine_similarity(feature_matrix_scaled, profile_scaled).flatten()
@@ -281,9 +271,16 @@ class LikedSongs:
         ----------
         filepath : str
             Path to write the JSON file (e.g., 'my_likes.json').
+
+        Raises
+        ------
+        OSError
+            If the file cannot be written (permissions, disk full, etc.).
         """
-        with open(filepath, "w") as f:
-            json.dump(list(self.liked_ids), f, indent=2)
+        path = Path(filepath)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as f:
+            json.dump(sorted(self.liked_ids), f, indent=2)
 
     def load(self, filepath: str) -> None:
         """
@@ -296,9 +293,30 @@ class LikedSongs:
         ----------
         filepath : str
             Path to the JSON file to load.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exist.
+        ValueError
+            If the file does not contain a JSON list of track IDs.
         """
-        with open(filepath, "r") as f:
-            ids = json.load(f)
+        path = Path(filepath)
+        if not path.exists():
+            raise FileNotFoundError(f"Liked songs file not found: {filepath}")
+
+        with path.open("r") as f:
+            try:
+                ids = json.load(f)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Could not parse liked songs file '{filepath}': {exc}"
+                ) from exc
+
+        if not isinstance(ids, list):
+            raise ValueError(
+                f"Liked songs file '{filepath}' must contain a JSON list of track IDs."
+            )
 
         skipped = 0
         for track_id in ids:

--- a/src/unwrapped/summary.py
+++ b/src/unwrapped/summary.py
@@ -8,10 +8,14 @@ dictionary.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
 from .clean import BOUNDED_AUDIO_COLUMNS, NUMERIC_COLUMNS, TEXT_COLUMNS
+
+DEFAULT_OUTPUT_DIR = "outputs"
 
 AUDIO_FEATURE_COLUMNS = [
     "danceability",
@@ -232,6 +236,10 @@ def target_correlations(
     """
 
     if target not in df.columns:
+        warnings.warn(
+            f"target column '{target}' not found; returning empty correlations",
+            stacklevel=2,
+        )
         return {}
 
     target_series = pd.to_numeric(df[target], errors="coerce")
@@ -243,6 +251,10 @@ def target_correlations(
         feature = pd.to_numeric(df[col], errors="coerce")
         valid = target_series.notna() & feature.notna()
         if valid.sum() < 2:
+            continue
+        # Skip constant columns: their zero variance would make pandas
+        # delegate to np.corrcoef and raise a divide-by-zero RuntimeWarning.
+        if target_series[valid].nunique() < 2 or feature[valid].nunique() < 2:
             continue
         correlations[col] = round(float(target_series[valid].corr(feature[valid])), 4)
 
@@ -264,6 +276,10 @@ def genre_summary(df: pd.DataFrame) -> pd.DataFrame:
     """
 
     if "track_genre" not in df.columns:
+        warnings.warn(
+            "'track_genre' column missing; returning empty genre summary",
+            stacklevel=2,
+        )
         return pd.DataFrame()
 
     feature_cols = [c for c in AUDIO_FEATURE_COLUMNS if c in df.columns]
@@ -299,6 +315,13 @@ def popularity_by_genre_pivot(
     """
 
     if "track_genre" not in df.columns or "popularity" not in df.columns:
+        missing = [
+            c for c in ("track_genre", "popularity") if c not in df.columns
+        ]
+        warnings.warn(
+            f"columns {missing} missing; returning empty popularity pivot",
+            stacklevel=2,
+        )
         return pd.DataFrame()
 
     if bins is None:
@@ -354,7 +377,9 @@ def summarize_data(df: pd.DataFrame) -> dict[str, object]:
     }
 
 
-def export_summary_csvs(df: pd.DataFrame, output_dir: str = "outputs") -> dict[str, str]:
+def export_summary_csvs(
+    df: pd.DataFrame, output_dir: str = DEFAULT_OUTPUT_DIR
+) -> dict[str, str]:
     """Export key summary results as CSV files for the visualization module.
 
     Writes four CSV files that the visualization team can load directly
@@ -373,7 +398,7 @@ def export_summary_csvs(df: pd.DataFrame, output_dir: str = "outputs") -> dict[s
     ----------
     df : pd.DataFrame
         Spotify dataset to summarize and export.
-    output_dir : str, default "outputs"
+    output_dir : str, default :data:`DEFAULT_OUTPUT_DIR`
         Directory to write CSV files into. Created if it does not exist.
 
     Returns

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -120,6 +120,8 @@ def test_coerce_numeric_columns_counts_values_converted_to_missing() -> None:
     """Non-numeric strings should become missing in numeric columns."""
 
     df = make_valid_df()
+    df["tempo"] = df["tempo"].astype(object)
+    df["popularity"] = df["popularity"].astype(object)
     df.loc[0, "tempo"] = "fast"
     df.loc[1, "popularity"] = "very popular"
 

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
+from sklearn.linear_model import LinearRegression
 
 from unwrapped.popularity import (
-    validate_data,
+    compare_models,
+    cross_validate_model,
+    evaluate_model,
+    get_feature_importance,
     handle_missing_values,
     preprocess_data,
+    run_popularity_pipeline,
+    save_outputs,
     split_data,
     train_linear_model,
     train_random_forest,
-    evaluate_model,
-    compare_models,
-    get_feature_importance,
+    validate_data,
 )
 
 
@@ -249,3 +255,85 @@ def test_get_feature_importance_sorted_desc(sample_df):
     importances = get_feature_importance(model, X_train, top_n=5)
 
     assert importances["importance"].is_monotonic_decreasing
+
+
+# Cross-validation should return RMSE and R^2 summary statistics.
+def test_cross_validate_model_returns_expected_keys(sample_df):
+    processed = preprocess_data(sample_df)
+    X_train, _, y_train, _ = split_data(processed, test_size=0.25)
+
+    cv_results = cross_validate_model(LinearRegression(), X_train, y_train, cv=3)
+
+    assert set(cv_results.keys()) == {"cv_rmse_mean", "cv_rmse_std", "cv_r2_mean"}
+    assert isinstance(cv_results["cv_rmse_mean"], float)
+    assert cv_results["cv_rmse_mean"] >= 0
+    assert cv_results["cv_rmse_std"] >= 0
+
+
+# save_outputs should write three CSVs into the requested directory.
+def test_save_outputs_writes_three_csvs(tmp_path: Path):
+    comparison = pd.DataFrame({"model": ["A", "B"], "rmse": [1.0, 2.0]})
+    importance = pd.DataFrame({"feature": ["x", "y"], "importance": [0.6, 0.4]})
+    predictions = pd.DataFrame(
+        {"actual_popularity": [50, 60], "linear_prediction": [49.0, 61.0]}
+    )
+
+    output_dir = tmp_path / "nested" / "outputs"
+    paths = save_outputs(comparison, importance, predictions, output_dir=output_dir)
+
+    assert set(paths.keys()) == {"comparison", "feature_importance", "predictions"}
+    assert (output_dir / "popularity_model_comparison.csv").exists()
+    assert (output_dir / "popularity_feature_importance.csv").exists()
+    assert (output_dir / "popularity_predictions.csv").exists()
+
+    round_trip = pd.read_csv(output_dir / "popularity_model_comparison.csv")
+    assert list(round_trip.columns) == ["model", "rmse"]
+
+
+# run_popularity_pipeline should call load_data, train both models, and save outputs.
+def test_run_popularity_pipeline_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, sample_df
+):
+    # Expand the fixture with more rows so cross-validation has enough data.
+    big_df = pd.concat([sample_df] * 6, ignore_index=True)
+    big_df["track_id"] = [str(i) for i in range(len(big_df))]
+
+    def fake_load(path: str) -> pd.DataFrame:
+        assert path == "fake.csv"
+        return big_df
+
+    monkeypatch.setattr("unwrapped.popularity.load_data", fake_load)
+
+    output_dir = tmp_path / "pipeline_outputs"
+    result = run_popularity_pipeline(
+        data_path="fake.csv",
+        save_results=True,
+        output_dir=output_dir,
+    )
+
+    assert {"linear_model", "random_forest_model", "comparison",
+            "feature_importance", "predictions"} <= result.keys()
+    assert not result["comparison"].empty
+    assert not result["feature_importance"].empty
+    assert (output_dir / "popularity_model_comparison.csv").exists()
+    assert (output_dir / "popularity_feature_importance.csv").exists()
+    assert (output_dir / "popularity_predictions.csv").exists()
+
+
+# Passing save_results=False should skip writing files.
+def test_run_popularity_pipeline_skips_saving_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, sample_df
+):
+    big_df = pd.concat([sample_df] * 6, ignore_index=True)
+    big_df["track_id"] = [str(i) for i in range(len(big_df))]
+
+    monkeypatch.setattr("unwrapped.popularity.load_data", lambda _: big_df)
+
+    output_dir = tmp_path / "should_not_exist"
+    run_popularity_pipeline(
+        data_path="fake.csv",
+        save_results=False,
+        output_dir=output_dir,
+    )
+
+    assert not output_dir.exists()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -269,7 +269,8 @@ class TestTargetCorrelations:
 
     def test_returns_empty_when_target_missing(self) -> None:
         df = make_test_df().drop(columns=["popularity"])
-        result = target_correlations(df)
+        with pytest.warns(UserWarning, match="target column"):
+            result = target_correlations(df)
 
         assert result == {}
 
@@ -293,7 +294,8 @@ class TestGenreSummary:
 
     def test_returns_empty_when_no_genre_column(self) -> None:
         df = make_test_df().drop(columns=["track_genre"])
-        result = genre_summary(df)
+        with pytest.warns(UserWarning, match="track_genre"):
+            result = genre_summary(df)
 
         assert result.empty
 
@@ -334,7 +336,8 @@ class TestPopularityByGenrePivot:
 
     def test_returns_empty_when_columns_missing(self) -> None:
         df = make_test_df().drop(columns=["track_genre"])
-        result = popularity_by_genre_pivot(df)
+        with pytest.warns(UserWarning, match="missing"):
+            result = popularity_by_genre_pivot(df)
 
         assert result.empty
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,8 +1,16 @@
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
 import pandas as pd
+import pytest
 
 from unwrapped.visualization import (
     plot_popularity_distribution,
     plot_top_genres,
+    save_figure,
 )
 
 
@@ -32,3 +40,33 @@ def test_plot_popularity_distribution_runs():
 
     assert fig is not None
     assert ax is not None
+
+
+def test_plot_top_genres_raises_when_genre_column_missing():
+    df = pd.DataFrame({"popularity": [90, 80, 75]})
+
+    with pytest.raises(ValueError, match="track_genre"):
+        plot_top_genres(df)
+
+
+def test_plot_popularity_distribution_raises_when_popularity_missing():
+    df = pd.DataFrame({"track_genre": ["pop", "rock"]})
+
+    with pytest.raises(ValueError, match="popularity"):
+        plot_popularity_distribution(df)
+
+
+def test_save_figure_writes_file_and_creates_parent_dirs(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "track_genre": ["pop", "rock", "jazz"],
+            "popularity": [90, 70, 50],
+        }
+    )
+    fig, _ = plot_popularity_distribution(df, bins=3)
+
+    output_path = tmp_path / "nested" / "subdir" / "figure.png"
+    save_figure(fig, output_path)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0


### PR DESCRIPTION
Cleans up the issues I found while reviewing the repo. All 135 tests pass, coverage goes from 92% to 97%, and the pytest run is down to zero warnings (was 25).

## What changed

**Bugs / warnings fixed**
- `analysis.compute_genre_deviations` threw a "Mean of empty slice" warning when a genre only had one track (all z-scores NaN). Now it only runs `nanmean` on rows that have at least one valid value.
- `LikedSongs.predict` was passing a raw numpy array into `MinMaxScaler.transform`, which made sklearn complain about missing feature names. Wrapping the profile as a DataFrame fixes it.
- `target_correlations` hit a divide-by-zero warning on constant columns. It now skips any column where the target or the feature has zero variance.
- `test_clean.py` was assigning a string into a float column, which raises a pandas FutureWarning. Fixed by casting the column to `object` first.

**Refactors**
- Pulled the duplicated `AUDIO_FEATURES` list out of `analysis.py` and `preference.py` into a new `constants.py`.
- Rewrote `popularity.py` with type hints and docstrings. `save_outputs` and `run_popularity_pipeline` now take an `output_dir` argument instead of hardcoding `"outputs"`, and `save_outputs` returns the paths it wrote.
- `preference.LikedSongs.save` now creates parent directories; `.load` raises a real `FileNotFoundError` or `ValueError` instead of letting things blow up mid-parse.
- `summary.py` now emits a `UserWarning` when a required column is missing instead of silently returning an empty result.
- `analysis.popularity_by_feature_buckets` validates its inputs up front with useful error messages.
- `__init__.py` exports `LikedSongs`, `run_popularity_pipeline`, and `AUDIO_FEATURES` so they're actually reachable from the package root.

**New tests**
- `test_popularity.py`: added end-to-end coverage for `cross_validate_model`, `save_outputs`, and `run_popularity_pipeline` (both with and without saving). Popularity coverage went from 69% to 98%.
- `test_visualization.py`: added a test for `save_figure` including nested directories, plus the error branches for the two plot functions. Visualization is now at 100%.

**Other**
- Added `requirements.txt` derived from `pyproject.toml` so the env is reproducible without doing an editable install.

## Coverage

| module | before | after |
|---|---|---|
| popularity.py | 69% | 98% |
| visualization.py | 83% | 100% |
| summary.py | 97% | 98% |
| **total** | **92%** | **97%** |

## How to test

```
pytest
pytest --cov=src/unwrapped
```

Or to sanity check the new imports:
```python
from unwrapped import run_popularity_pipeline, LikedSongs, AUDIO_FEATURES
```