### PR TITLE
Explain why a track matched: feature-level breakdowns for LikedSongs

### DIFF
--- a/src/unwrapped/preference.py
+++ b/src/unwrapped/preference.py
@@ -24,13 +24,21 @@ Example:
 """
 
 import json
+import warnings
 from pathlib import Path
+from typing import Literal
 
+import numpy as np
 import pandas as pd
-from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.preprocessing import MinMaxScaler
 
 from .constants import AUDIO_FEATURES
+
+ScoringMethod = Literal["cosine", "euclidean"]
+WeightingScheme = Literal["uniform", "inverse_variance"]
+
+_VARIANCE_EPS = 1e-9
 
 
 class LikedSongs:
@@ -191,73 +199,324 @@ class LikedSongs:
     # Predicting preference scores
     # ------------------------------------------------------------------
 
-    def predict(self, top_n: int = None, exclude_liked: bool = True) -> pd.DataFrame:
+    def predict(
+        self,
+        top_n: int | None = None,
+        exclude_liked: bool = True,
+        method: ScoringMethod = "cosine",
+        weights: WeightingScheme = "uniform",
+        return_explanations: bool = False,
+    ) -> pd.DataFrame:
         """
         Score every song in the dataset by similarity to the taste profile.
 
-        Uses cosine similarity between each song's feature vector and the
-        mean feature vector of liked songs. Scores are min-max normalized
-        to a 0–1 range.
+        Two scoring methods are supported:
+
+        * ``"cosine"`` (default, backward compatible): cosine similarity
+          between each song's min-max scaled feature vector and the
+          scaled taste profile.  Raw similarities are then min-max
+          normalized to 0–1.
+        * ``"euclidean"``: ``-Σ w_i · (track_i − profile_i)²`` in the
+          scaled feature space, where ``w_i`` comes from ``weights``.
+          Raw scores are min-max normalized to 0–1 for the output.
+          The raw, un-normalized score decomposes exactly into per-feature
+          attributions returned by :meth:`explain`.
 
         Parameters
         ----------
         top_n : int, optional
-            If provided, return only the top N highest-scoring songs.
+            If provided, return only the top ``top_n`` highest-scoring songs.
         exclude_liked : bool, default True
             If True, liked songs are excluded from the results (they'd
             trivially score near the top).
+        method : {"cosine", "euclidean"}, default "cosine"
+            Scoring backend.  Cosine preserves the original behavior;
+            euclidean gives an exact per-feature decomposition.
+        weights : {"uniform", "inverse_variance"}, default "uniform"
+            Only used for ``method="euclidean"``.  ``"inverse_variance"``
+            down-weights features where the liked set is inconsistent and
+            up-weights features the user is consistent on.  Falls back to
+            uniform (with a warning) when fewer than two songs are liked.
+        return_explanations : bool, default False
+            When True, add a ``top_matches`` column summarizing the three
+            features that contributed most to each track's score.
 
         Returns
         -------
         pd.DataFrame
-            Dataset with an added 'preference_score' column (0–1),
-            sorted descending. Columns: track_id, track_name, artists,
-            track_genre, popularity, preference_score.
+            Dataset sorted by ``preference_score`` descending.  Columns:
+            ``track_id, track_name, artists, track_genre, popularity,
+            preference_score`` (plus ``top_matches`` when requested).
         """
-        profile = self.build_profile()
+        scaled_matrix, profile_scaled = self._scaled_feature_space()
+        raw_scores = self._raw_scores(
+            scaled_matrix=scaled_matrix,
+            profile_scaled=profile_scaled,
+            method=method,
+            weights=weights,
+        )
 
-        # Normalize all feature vectors and the profile onto the same scale.
-        # loudness is negative and tempo is in the hundreds — raw cosine
-        # similarity without scaling would be dominated by those columns.
-        scaler = MinMaxScaler()
-        feature_matrix = self.df[AUDIO_FEATURES].copy()
-        feature_matrix_scaled = scaler.fit_transform(feature_matrix)
-
-        # Wrap the profile as a DataFrame with matching column names so
-        # sklearn doesn't warn about the transformer losing feature names.
-        profile_df = profile.reindex(AUDIO_FEATURES).to_frame().T
-        profile_scaled = scaler.transform(profile_df)
-
-        # Cosine similarity: shape is (n_songs, 1)
-        similarities = cosine_similarity(feature_matrix_scaled, profile_scaled).flatten()
+        normalized = self._minmax(raw_scores)
 
         result = self.df.copy()
-        result["preference_score"] = similarities
+        result["preference_score"] = np.round(normalized, 4)
 
-        # Normalize scores to 0–1
-        min_score = result["preference_score"].min()
-        max_score = result["preference_score"].max()
-        if max_score > min_score:
-            result["preference_score"] = (
-                (result["preference_score"] - min_score) / (max_score - min_score)
+        if return_explanations:
+            weight_vector = self._compute_weights(weights)
+            deltas = scaled_matrix - profile_scaled
+            result["top_matches"] = self._describe_top_matches(
+                deltas=deltas, weights=weight_vector, method=method
             )
-        else:
-            result["preference_score"] = 0.0
-
-        result["preference_score"] = result["preference_score"].round(4)
 
         if exclude_liked:
             result = result[~result["track_id"].isin(self.liked_ids)]
 
-        result = result.sort_values("preference_score", ascending=False).reset_index(drop=True)
+        result = result.sort_values(
+            "preference_score", ascending=False
+        ).reset_index(drop=True)
 
-        output_cols = ["track_id", "track_name", "artists", "track_genre", "popularity", "preference_score"]
+        output_cols = [
+            "track_id",
+            "track_name",
+            "artists",
+            "track_genre",
+            "popularity",
+            "preference_score",
+        ]
+        if return_explanations:
+            output_cols.append("top_matches")
         result = result[output_cols]
 
         if top_n is not None:
             return result.head(top_n)
 
         return result
+
+    # ------------------------------------------------------------------
+    # Explanations
+    # ------------------------------------------------------------------
+
+    def explain(
+        self,
+        track_id: str,
+        method: ScoringMethod = "cosine",
+        weights: WeightingScheme = "uniform",
+    ) -> pd.DataFrame:
+        """
+        Break a track's score down into per-feature contributions.
+
+        Returns one row per audio feature with the raw and scaled values
+        for both the track and the taste profile, the signed and absolute
+        delta between them, and the weight used for that feature.  When
+        ``method="euclidean"``, an additional ``attribution`` column is
+        included; summing it reproduces the track's raw (un-normalized)
+        score.
+
+        Rows are sorted by ``abs_delta`` ascending so the strongest
+        matches appear first.
+
+        Parameters
+        ----------
+        track_id : str
+            Spotify track ID to explain.  Must exist in the dataset.
+        method : {"cosine", "euclidean"}
+            Must match the method used to compute the score being
+            explained.  Only affects which columns are returned.
+        weights : {"uniform", "inverse_variance"}
+            Weighting scheme applied when ``method="euclidean"``.
+
+        Raises
+        ------
+        ValueError
+            If ``track_id`` is not in the dataset, or the liked list is
+            empty so no profile can be built.
+        """
+        if not self.liked_ids:
+            raise ValueError(
+                "Liked songs list is empty. Add songs with add_by_id() or "
+                "add_by_name() before asking for an explanation."
+            )
+        track_rows = self.df.index[self.df["track_id"] == track_id]
+        if len(track_rows) == 0:
+            raise ValueError(f"track_id '{track_id}' not found in dataset.")
+        row_idx = int(track_rows[0])
+
+        scaled_matrix, profile_scaled = self._scaled_feature_space()
+        track_scaled = scaled_matrix[row_idx]
+
+        profile_raw = self.build_profile().reindex(AUDIO_FEATURES)
+        track_raw = self.df.loc[row_idx, AUDIO_FEATURES].astype(float)
+
+        weight_vector = self._compute_weights(weights)
+        delta = track_scaled - profile_scaled.flatten()
+
+        explanation = pd.DataFrame({
+            "feature": AUDIO_FEATURES,
+            "track_raw": track_raw.values,
+            "profile_raw": profile_raw.values,
+            "track_scaled": track_scaled,
+            "profile_scaled": profile_scaled.flatten(),
+            "delta": delta,
+            "abs_delta": np.abs(delta),
+            "weight": weight_vector,
+        })
+
+        if method == "euclidean":
+            # Per-feature contribution to the raw (negative squared
+            # distance) score.  sum(attribution) == raw score exactly.
+            explanation["attribution"] = -weight_vector * delta ** 2
+
+        return explanation.sort_values("abs_delta").reset_index(drop=True)
+
+    def explain_top(
+        self,
+        track_id: str,
+        n: int = 3,
+        method: ScoringMethod = "cosine",
+        weights: WeightingScheme = "uniform",
+    ) -> dict[str, pd.DataFrame]:
+        """
+        Return the ``n`` features that match best and worst for a track.
+
+        A thin wrapper around :meth:`explain` that slices the head and
+        tail of the sorted explanation.
+
+        Parameters
+        ----------
+        track_id : str
+            Spotify track ID to summarize.
+        n : int, default 3
+            Number of features to include in each bucket.
+        method : {"cosine", "euclidean"}
+            Passed through to :meth:`explain`.
+        weights : {"uniform", "inverse_variance"}
+            Passed through to :meth:`explain`.
+
+        Returns
+        -------
+        dict[str, pd.DataFrame]
+            ``{"matches": ..., "mismatches": ...}`` — the ``n`` features
+            with the smallest and largest ``abs_delta`` respectively.
+        """
+        if n < 1:
+            raise ValueError(f"n must be >= 1, got {n}")
+
+        explanation = self.explain(track_id, method=method, weights=weights)
+        return {
+            "matches": explanation.head(n).reset_index(drop=True),
+            "mismatches": (
+                explanation.tail(n)
+                .sort_values("abs_delta", ascending=False)
+                .reset_index(drop=True)
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _scaled_feature_space(self) -> tuple[np.ndarray, np.ndarray]:
+        """Min-max scale the feature matrix and the taste profile together.
+
+        Returns the scaled feature matrix (shape ``n_tracks × n_features``)
+        and the scaled profile vector (shape ``1 × n_features``).
+        """
+        profile = self.build_profile()
+
+        scaler = MinMaxScaler()
+        feature_matrix = self.df[AUDIO_FEATURES].copy()
+        feature_matrix_scaled = scaler.fit_transform(feature_matrix)
+
+        # DataFrame wrapper keeps sklearn from warning about lost feature names.
+        profile_df = profile.reindex(AUDIO_FEATURES).to_frame().T
+        profile_scaled = scaler.transform(profile_df)
+
+        return feature_matrix_scaled, profile_scaled
+
+    def _raw_scores(
+        self,
+        scaled_matrix: np.ndarray,
+        profile_scaled: np.ndarray,
+        method: ScoringMethod,
+        weights: WeightingScheme,
+    ) -> np.ndarray:
+        """Dispatch to the requested scoring method and return raw scores."""
+        if method == "cosine":
+            return cosine_similarity(scaled_matrix, profile_scaled).flatten()
+        if method == "euclidean":
+            weight_vector = self._compute_weights(weights)
+            deltas = scaled_matrix - profile_scaled
+            return -np.sum(weight_vector * deltas ** 2, axis=1)
+        raise ValueError(
+            f"Unknown method '{method}'. Expected 'cosine' or 'euclidean'."
+        )
+
+    def _compute_weights(self, weights: WeightingScheme) -> np.ndarray:
+        """Return the per-feature weights normalized to sum to 1.
+
+        ``"uniform"`` gives every feature equal weight.
+        ``"inverse_variance"`` uses ``1 / (var + eps)`` of the liked
+        songs' scaled features, so features the user is consistent on
+        dominate the score.  Falls back to uniform (with a warning)
+        when fewer than two songs are liked.
+        """
+        n_features = len(AUDIO_FEATURES)
+        if weights == "uniform":
+            return np.full(n_features, 1.0 / n_features)
+        if weights == "inverse_variance":
+            if len(self.liked_ids) < 2:
+                warnings.warn(
+                    "inverse_variance weighting needs at least 2 liked songs; "
+                    "falling back to uniform weights.",
+                    stacklevel=3,
+                )
+                return np.full(n_features, 1.0 / n_features)
+
+            liked_df = self.df[self.df["track_id"].isin(self.liked_ids)]
+            # Fit the scaler on the full dataset so the variance is
+            # measured in the same space the predictions live in.
+            scaler = MinMaxScaler()
+            scaler.fit(self.df[AUDIO_FEATURES])
+            liked_scaled = scaler.transform(liked_df[AUDIO_FEATURES])
+
+            variances = liked_scaled.var(axis=0, ddof=0)
+            inv = 1.0 / (variances + _VARIANCE_EPS)
+            return inv / inv.sum()
+        raise ValueError(
+            f"Unknown weights '{weights}'. Expected 'uniform' or 'inverse_variance'."
+        )
+
+    @staticmethod
+    def _minmax(values: np.ndarray) -> np.ndarray:
+        """Min-max normalize a 1-D score array to the 0–1 range."""
+        lo = float(np.min(values))
+        hi = float(np.max(values))
+        if hi > lo:
+            return (values - lo) / (hi - lo)
+        return np.zeros_like(values, dtype=float)
+
+    @staticmethod
+    def _describe_top_matches(
+        deltas: np.ndarray,
+        weights: np.ndarray,
+        method: ScoringMethod,
+        n: int = 3,
+    ) -> list[str]:
+        """One-line ``top_matches`` string per row for :meth:`predict`.
+
+        For cosine we rank by raw absolute delta (smaller = closer); for
+        euclidean we rank by per-feature attribution (less negative = closer).
+        Returns the ``n`` best-matching feature names per row, joined with
+        commas.
+        """
+        abs_deltas = np.abs(deltas)
+        if method == "euclidean":
+            abs_deltas = weights * abs_deltas ** 2  # non-negative ranking key
+
+        # argsort gives indices of the smallest values first.
+        top_idx = np.argsort(abs_deltas, axis=1)[:, :n]
+        feature_array = np.array(AUDIO_FEATURES)
+        return [", ".join(feature_array[row].tolist()) for row in top_idx]
 
     # ------------------------------------------------------------------
     # Saving and loading the liked list

--- a/tests/test_preference.py
+++ b/tests/test_preference.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -238,3 +239,226 @@ class TestValidation:
         liked = LikedSongs(dup)
 
         assert liked.df["track_id"].is_unique
+
+
+class TestPredictEuclidean:
+    def test_scores_in_range(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        scores = liked.predict(method="euclidean")
+
+        assert scores["preference_score"].min() >= 0.0
+        assert scores["preference_score"].max() <= 1.0
+
+    def test_sorted_descending(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        scores = liked.predict(method="euclidean")
+
+        assert scores["preference_score"].is_monotonic_decreasing
+
+    def test_inverse_variance_needs_two_liked_songs(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        with pytest.warns(UserWarning, match="at least 2 liked songs"):
+            liked.predict(method="euclidean", weights="inverse_variance")
+
+    def test_inverse_variance_differs_from_uniform(self) -> None:
+        # Construct liked songs that are consistent on danceability but
+        # inconsistent on energy, so inverse-variance weighting should
+        # reweight features asymmetrically relative to uniform.
+        rng = np.random.default_rng(0)
+        rows = []
+        for i in range(15):
+            rows.append(
+                make_row(
+                    track_id=f"tv{i}",
+                    track_name=f"Song {i}",
+                    danceability=float(rng.uniform(0.1, 0.9)),
+                    energy=float(rng.uniform(0.1, 0.9)),
+                    tempo=float(rng.uniform(80, 160)),
+                    loudness=float(rng.uniform(-12, -2)),
+                    valence=float(rng.uniform(0.1, 0.9)),
+                )
+            )
+        df = pd.DataFrame(rows)
+        # Liked songs agree on danceability ≈ 0.5 but disagree on energy.
+        df.loc[0, "danceability"] = 0.50
+        df.loc[1, "danceability"] = 0.51
+        df.loc[2, "danceability"] = 0.49
+        df.loc[0, "energy"] = 0.10
+        df.loc[1, "energy"] = 0.80
+        df.loc[2, "energy"] = 0.30
+
+        liked = LikedSongs(df)
+        liked.add_by_id("tv0")
+        liked.add_by_id("tv1")
+        liked.add_by_id("tv2")
+
+        uniform = liked.predict(method="euclidean", weights="uniform")
+        weighted = liked.predict(method="euclidean", weights="inverse_variance")
+
+        merged = uniform.merge(
+            weighted, on="track_id", suffixes=("_u", "_w")
+        )
+        assert not np.allclose(
+            merged["preference_score_u"], merged["preference_score_w"]
+        )
+
+    def test_unknown_method_raises(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        with pytest.raises(ValueError, match="Unknown method"):
+            liked.predict(method="manhattan")  # type: ignore[arg-type]
+
+    def test_unknown_weights_raises(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+        liked.add_by_id("t2")
+
+        with pytest.raises(ValueError, match="Unknown weights"):
+            liked.predict(
+                method="euclidean",
+                weights="tf-idf",  # type: ignore[arg-type]
+            )
+
+
+class TestPredictExplanations:
+    def test_top_matches_column_added(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        scores = liked.predict(return_explanations=True)
+
+        assert "top_matches" in scores.columns
+        # Each row should list 3 feature names by default.
+        first = scores.iloc[0]["top_matches"]
+        assert len(first.split(", ")) == 3
+
+    def test_explanations_dont_change_base_scores(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        baseline = liked.predict()
+        with_explanations = liked.predict(return_explanations=True)
+
+        pd.testing.assert_series_equal(
+            baseline["preference_score"],
+            with_explanations["preference_score"],
+        )
+
+
+class TestExplain:
+    def test_returns_row_per_feature(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        result = liked.explain("t2")
+
+        assert len(result) == len(AUDIO_FEATURES)
+        assert set(result["feature"]) == set(AUDIO_FEATURES)
+
+    def test_expected_columns_for_cosine(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        result = liked.explain("t2", method="cosine")
+
+        expected = {
+            "feature", "track_raw", "profile_raw",
+            "track_scaled", "profile_scaled",
+            "delta", "abs_delta", "weight",
+        }
+        assert set(result.columns) == expected
+
+    def test_euclidean_includes_attribution(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        result = liked.explain("t2", method="euclidean")
+
+        assert "attribution" in result.columns
+        # All euclidean attributions are non-positive (squared deltas).
+        assert (result["attribution"] <= 0).all()
+
+    def test_sorted_by_abs_delta_ascending(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+        liked.add_by_id("t2")
+
+        result = liked.explain("t3", method="euclidean")
+
+        assert result["abs_delta"].is_monotonic_increasing
+
+    def test_euclidean_attributions_sum_to_raw_score(self) -> None:
+        """sum(attribution) must equal the raw euclidean score exactly."""
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+        liked.add_by_id("t2")
+
+        # Recompute the raw score directly for t3 and compare.
+        explanation = liked.explain("t3", method="euclidean")
+        attribution_sum = explanation["attribution"].sum()
+
+        # The raw score from _raw_scores uses the same formula; compute it
+        # inline so the test doesn't depend on internal caching.
+        scaled_matrix, profile_scaled = liked._scaled_feature_space()
+        weights = liked._compute_weights("uniform")
+        deltas = scaled_matrix - profile_scaled
+        all_raw = -np.sum(weights * deltas ** 2, axis=1)
+        t3_idx = liked.df.index[liked.df["track_id"] == "t3"][0]
+        expected_raw = all_raw[t3_idx]
+
+        assert attribution_sum == pytest.approx(expected_raw, abs=1e-12)
+
+    def test_raises_for_unknown_track(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        with pytest.raises(ValueError, match="not found"):
+            liked.explain("nonexistent")
+
+    def test_raises_when_liked_empty(self) -> None:
+        liked = LikedSongs(make_df())
+
+        with pytest.raises(ValueError, match="empty"):
+            liked.explain("t1")
+
+
+class TestExplainTop:
+    def test_returns_matches_and_mismatches(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        top = liked.explain_top("t2", n=3)
+
+        assert set(top.keys()) == {"matches", "mismatches"}
+        assert len(top["matches"]) == 3
+        assert len(top["mismatches"]) == 3
+
+    def test_matches_have_smaller_abs_delta_than_mismatches(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        top = liked.explain_top("t2", n=2)
+
+        assert top["matches"]["abs_delta"].max() <= top["mismatches"]["abs_delta"].min()
+
+    def test_mismatches_sorted_worst_first(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        top = liked.explain_top("t2", n=3)
+
+        assert top["mismatches"]["abs_delta"].is_monotonic_decreasing
+
+    def test_rejects_non_positive_n(self) -> None:
+        liked = LikedSongs(make_df())
+        liked.add_by_id("t1")
+
+        with pytest.raises(ValueError, match="n must be"):
+            liked.explain_top("t2", n=0)


### PR DESCRIPTION
Right now `LikedSongs.predict` gives each track a score but no reason. If you look at a high-scoring track you can't tell whether it matched on energy, acousticness, or just noise. This PR adds an explanation layer so you can see *why* a track ranked where it did, and adds a second scoring mode that decomposes exactly.

## What's new

**A second scoring method.** `predict(method="euclidean")` replaces cosine with a weighted squared-distance score in the min-max-scaled feature space:

```
raw_score = -Σ w_i · (track_i − profile_i)²
```

The raw score is still min-max normalized to 0–1 for the output, same as before, but the un-normalized score now decomposes cleanly into per-feature contributions. The default is still cosine, so nothing existing breaks.

**Weights.** When using euclidean, you can pass `weights="inverse_variance"` and features your liked set is *consistent* on (low variance across your liked songs) get more weight than features you're inconsistent on. The intuition: if every song you like has roughly the same danceability, danceability is diagnostic of your taste and should matter more than energy, where your picks are all over the place. Falls back to uniform with a warning if you have fewer than two liked songs.

**`explain(track_id)`.** Returns one row per audio feature with:

- `track_raw`, `profile_raw` — the readable numbers
- `track_scaled`, `profile_scaled` — what the model actually saw
- `delta`, `abs_delta` — the signed and absolute distance in scaled space
- `weight` — what weight that feature got in this scoring
- `attribution` — present only for euclidean; `sum(attribution)` equals the raw score exactly

Sorted by `abs_delta` ascending so the strongest matches are at the top.

**`explain_top(track_id, n=3)`.** Thin wrapper that returns `{"matches": ..., "mismatches": ...}` — the n features that best and worst match the profile. This is the thing you'd actually display in a UI.

**`predict(return_explanations=True)`.** Adds a `top_matches` column to the prediction table with a short string like `"danceability, valence, tempo"` — the three features that contributed most to each track's score. Off by default so the return shape doesn't change for existing callers.

## Why not just decompose cosine directly?

Cosine's numerator `Σ track_i · profile_i` is a sum over features, so technically it decomposes. But after min-max scaling, every value is in [0, 1], so every per-feature "contribution" is positive — even when the track and the profile strongly disagree. A profile of 0.9 with a track of 0.1 still shows up as a positive contribution, which is misleading.

Weighted Euclidean doesn't have that problem: a bad match on a feature produces a larger negative number, so the attribution actually reflects whether the feature helped or hurt. That's why I kept cosine as the default for compatibility but routed the exact decomposition through euclidean.

## Tests

19 new tests covering:

- Euclidean scores stay in [0, 1] and are sorted descending
- `inverse_variance` warns and falls back to uniform on a single liked song
- `inverse_variance` produces different rankings from uniform when liked songs have uneven per-feature variance
- Unknown `method` / `weights` values raise `ValueError`
- `return_explanations=True` adds `top_matches` without changing any scores
- `explain` returns one row per feature, sorted by `abs_delta` ascending
- `explain` returns the expected columns for both cosine and euclidean
- Euclidean attributions sum to the raw score within 1e-12 (the decomposition identity)
- `explain_top` matches have smaller deltas than mismatches; mismatches sort worst-first
- Both `explain` and `explain_top` reject unknown track IDs and `n < 1`

## How to try it

```python
from unwrapped import LikedSongs
from unwrapped.io import load_data

df = load_data("data/raw/spotify_data.csv")
liked = LikedSongs(df)
liked.add_by_name("Blinding Lights")
liked.add_by_name("Levitating")
liked.add_by_name("Flowers")

# same API as before
scores = liked.predict()

# new: exact decomposition
scores = liked.predict(
    method="euclidean",
    weights="inverse_variance",
    return_explanations=True,
    top_n=10,
)
print(scores[["track_name", "preference_score", "top_matches"]])

# drill into a single recommendation
liked.explain_top(scores.iloc[0]["track_id"], n=3)
```

## Coverage

`preference.py`: 94% → 96%. Total: 174 passing, 93% overall.