### PR TITLE
Add load_json for JSON export support

### DIFF
--- a/src/unwrapped/io.py
+++ b/src/unwrapped/io.py
@@ -27,3 +27,11 @@ def load_data(path: str) -> pd.DataFrame:
         df = df.drop(columns=["Unnamed: 0"])
 
     return df
+
+def load_json(path: str) -> pd.DataFrame:
+    """Load a Spotify JSON export into a DataFrame."""
+    df = pd.read_json(path)
+    if "Unnamed: 0" in df.columns:
+        df = df.drop(columns=["Unnamed: 0"])
+    return df
+

--- a/src/unwrapped/io.py
+++ b/src/unwrapped/io.py
@@ -4,6 +4,11 @@ import pandas as pd
 
 DEFAULT_DATA_PATH = "data/raw/spotify_data.csv"
 
+def _drop_index_column(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove the Unnamed: 0 export index column if present."""
+    if "Unnamed: 0" in df.columns:
+        df = df.drop(columns=["Unnamed: 0"])
+    return df
 
 def load_data(path: str) -> pd.DataFrame:
     """Load the raw Spotify CSV into a pandas DataFrame.
@@ -21,17 +26,22 @@ def load_data(path: str) -> pd.DataFrame:
     """
 
     df = pd.read_csv(path)
-
-    # Some CSV exports include the old row index as an extra column.
-    if "Unnamed: 0" in df.columns:
-        df = df.drop(columns=["Unnamed: 0"])
-
-    return df
+    return _drop_index_column(df)
 
 def load_json(path: str) -> pd.DataFrame:
-    """Load a Spotify JSON export into a DataFrame."""
+    """Load a Spotify JSON export into a pandas DataFrame.
+
+    Parameters
+    ----------
+    path : str
+        Path to the JSON file to load.
+
+    Returns
+    -------
+    pd.DataFrame
+        Raw Spotify dataset with the common export index column removed when
+        present.
+    """
     df = pd.read_json(path)
-    if "Unnamed: 0" in df.columns:
-        df = df.drop(columns=["Unnamed: 0"])
-    return df
+    return _drop_index_column(df)
 

--- a/src/unwrapped/io.py
+++ b/src/unwrapped/io.py
@@ -10,6 +10,7 @@ def _drop_index_column(df: pd.DataFrame) -> pd.DataFrame:
         df = df.drop(columns=["Unnamed: 0"])
     return df
 
+
 def load_data(path: str) -> pd.DataFrame:
     """Load the raw Spotify CSV into a pandas DataFrame.
 
@@ -27,6 +28,7 @@ def load_data(path: str) -> pd.DataFrame:
 
     df = pd.read_csv(path)
     return _drop_index_column(df)
+
 
 def load_json(path: str) -> pd.DataFrame:
     """Load a Spotify JSON export into a pandas DataFrame.


### PR DESCRIPTION
The project description mentions both JSON/CSV exports but io.py only handled CSV. This adds a load_json() function that loads a Spotify JSON export into a DataFrame and drops the unnamed 0 index column if present. 