### PR TITLE
Fix validate_ranges handling of missing values

### DIFF
--- a/src/unwrapped/validation.py
+++ b/src/unwrapped/validation.py
@@ -40,7 +40,7 @@ def validate_ranges(df: pd.DataFrame) -> None:
     errors = []
 
     def check_range(col: str, low: float, high: float) -> None:
-        if not df[col].between(low, high).all():
+        if not df[col].dropna().between(low, high).all():
             errors.append(f"{col} out of range [{low}, {high}]")
 
     check_range("danceability", 0, 1)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -152,10 +152,28 @@ def test_validate_ranges_aggregates_multiple_failures() -> None:
     assert "duration_ms contains non-positive values" in message
 
 
-def test_validate_ranges_treats_missing_numeric_values_as_invalid() -> None:
-    """NaN in checked range columns should fail instead of silently passing."""
+def test_validate_ranges_ignores_missing_numeric_values() -> None:
+    """NaN in checked range columns should be excluded from range checks."""
 
-    df = pd.DataFrame([make_valid_row(energy=float("nan"))])
+    df = pd.DataFrame(
+        [
+            make_valid_row(energy=float("nan")),
+            make_valid_row(track_id="track-2", valence=float("nan")),
+        ]
+    )
+
+    validate_ranges(df)
+
+
+def test_validate_ranges_rejects_non_missing_out_of_range_values() -> None:
+    """Real out-of-range values should still fail even if other rows are missing."""
+
+    df = pd.DataFrame(
+        [
+            make_valid_row(energy=float("nan")),
+            make_valid_row(track_id="track-2", energy=1.2),
+        ]
+    )
 
     with pytest.raises(ValueError) as exc_info:
         validate_ranges(df)


### PR DESCRIPTION
Closes #29

## Summary
Fix `validate_ranges` so missing values are ignored during range checks instead of being treated as out-of-range.

## Changes
- updated `validate_ranges` to drop missing values before calling `between`
- replaced the old missing-value expectation test
- added a regression test showing real non-missing out-of-range values still fail

## Verification
- `pytest -q` → `175 passed in 12.45s`