### PR TITLE
Add JSON loading demo script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ unwrapped/
 ├── scripts/                # Demo scripts for each workflow
 │   ├── demo_analysis.py    # Main analysis (research questions)
 │   ├── demo_cleaning.py    # Cleaning pipeline demo
+│   ├── demo_json_loading.py  # JSON loading demo
 │   ├── demo_summary.py     # Descriptive statistics demo
 │   ├── demo_validation.py  # Data quality checks demo
 │   └── demo_visualization.py  # Chart generation
 ├── src/unwrapped/          # Package source code
-│   ├── io.py               # CSV loading
+│   ├── io.py               # CSV and JSON loading
 │   ├── clean.py            # Data cleaning pipeline
 │   ├── validation.py       # Schema and range validation
 │   ├── summary.py          # Descriptive statistics / EDA
@@ -92,8 +93,9 @@ unwrapped/
 
 ### Data Loading (`io.py`)
 
-Reads the raw CSV into a pandas DataFrame. Automatically removes the
-`Unnamed: 0` index column that some Spotify CSV exports include.
+Reads Spotify data into a pandas DataFrame. Supports both CSV ('load_data')
+and JSON ('load_json') formats. Automatically removes the `Unnamed: 0` 
+index column that some Spotify exports include.
 
 ### Cleaning (`clean.py`)
 

--- a/scripts/demo_json_loading.py
+++ b/scripts/demo_json_loading.py
@@ -1,0 +1,39 @@
+"""Demonstrate loading a Spotify dataset sample via the JSON loader."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from unwrapped.io import DEFAULT_DATA_PATH, load_data, load_json
+
+
+def main() -> None:
+    """Load the CSV, save a sample as JSON, reload it, and print a preview."""
+
+    print("Loading CSV dataset...")
+    df = load_data(DEFAULT_DATA_PATH)
+
+    sample = df.head(10)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False
+    ) as tmp:
+        tmp_path = Path(tmp.name)
+        tmp.write(json.dumps(sample.to_dict(orient="records")))
+
+    print(f"\nSaved 10-row sample to temporary JSON file: {tmp_path.name}")
+
+    loaded_df = load_json(str(tmp_path))
+
+    print(f"\nLoaded JSON shape: {loaded_df.shape}")
+    print("\nColumns:", list(loaded_df.columns))
+    print("\nData preview:")
+    print(loaded_df.head())
+
+    tmp_path.unlink()
+    print("\nTemporary file cleaned up.")
+
+if __name__ == "__main__":
+    main()
+
+


### PR DESCRIPTION
Adds demo_json_loading.py to scripts/ to demonstrate the load_json function using real Spotify data.
It demo loads the CSV, saves a 10-row sample as JSON, reloads it with load_json, and prints the shape. columns, and a data preview. 
Also, updated README to reflect JSON support in io.py, the description now mentions both load_data and load_json
Also updates the project structure in the README to include the new demo script and corrects io.py comment. 
