### PR TITLE
Fix runtime crashes in validation and preference modules

### DIFF
--- a/scripts/demo_validation.py
+++ b/scripts/demo_validation.py
@@ -7,7 +7,23 @@ from unwrapped.validation import run_validation
 
 
 def main() -> None:
-    _, report = run_validation(DEFAULT_DATA_PATH)
+    df, report = run_validation(DEFAULT_DATA_PATH)
+
+    violations = report.get("range_violations", {})
+    dirty = {col: n for col, n in violations.items() if n > 0}
+    if dirty:
+        print("Range violations detected (per column):")
+        for col, n in dirty.items():
+            print(f"  {col}: {n}")
+        print()
+
+    print(f"Rows: {report['num_rows']:,}  Columns: {report['num_columns']}")
+    print(f"Unique tracks: {report['unique_tracks']:,}")
+    print(f"Duplicate rows: {report['duplicate_rows']}")
+    print(f"Duplicate track_ids: {report['duplicate_track_ids']}")
+    print(f"Inconsistent tracks: {report['inconsistent_tracks']}")
+
+    print("\nFull report:")
     pprint(report)
 
 

--- a/src/unwrapped/preference.py
+++ b/src/unwrapped/preference.py
@@ -92,7 +92,7 @@ class LikedSongs:
             )
         self.liked_ids.add(track_id)
 
-    def add_by_name(self, track_name: str, artist: str = None) -> None:
+    def add_by_name(self, track_name: str, artist: str | None = None) -> None:
         """
         Add a song to the liked list by track name (case-insensitive).
 
@@ -105,15 +105,25 @@ class LikedSongs:
             The name of the track to search for.
         artist : str, optional
             Artist name to narrow the search when there are duplicates.
+            Matched as a case-insensitive substring (not a regex), so
+            names containing ``(``, ``.``, etc. are safe.
 
         Raises
         ------
         ValueError
             If no matching track is found.
         """
-        mask = self.df["track_name"].str.lower() == track_name.lower()
+        names = self.df["track_name"].fillna("").str.lower()
+        mask = names == track_name.lower()
         if artist:
-            mask &= self.df["artists"].str.lower().str.contains(artist.lower())
+            # regex=False keeps special characters in artist names (parens,
+            # dots, plus signs) from being interpreted as regex metachars.
+            mask &= (
+                self.df["artists"]
+                .fillna("")
+                .str.lower()
+                .str.contains(artist.lower(), regex=False, na=False)
+            )
 
         matches = self.df[mask]
         if matches.empty:
@@ -206,6 +216,7 @@ class LikedSongs:
         method: ScoringMethod = "cosine",
         weights: WeightingScheme = "uniform",
         return_explanations: bool = False,
+        deduplicate: bool = True,
     ) -> pd.DataFrame:
         """
         Score every song in the dataset by similarity to the taste profile.
@@ -240,6 +251,11 @@ class LikedSongs:
         return_explanations : bool, default False
             When True, add a ``top_matches`` column summarizing the three
             features that contributed most to each track's score.
+        deduplicate : bool, default True
+            When True, collapse rows that share the same ``(track_name,
+            artists)`` pair, keeping only the highest-scoring row.  The
+            Spotify dataset stores the same song once per genre tag, so
+            a single song can otherwise dominate the top N.
 
         Returns
         -------
@@ -274,6 +290,16 @@ class LikedSongs:
         result = result.sort_values(
             "preference_score", ascending=False
         ).reset_index(drop=True)
+
+        if deduplicate:
+            # Keep the highest-scoring row for each (track_name, artists)
+            # pair. drop_duplicates keeps the first occurrence, and the
+            # frame is already sorted by score descending.
+            result = (
+                result.dropna(subset=["track_name", "artists"])
+                .drop_duplicates(subset=["track_name", "artists"])
+                .reset_index(drop=True)
+            )
 
         output_cols = [
             "track_id",

--- a/src/unwrapped/validation.py
+++ b/src/unwrapped/validation.py
@@ -36,6 +36,18 @@ def validate_schema(df: pd.DataFrame) -> None:
         print(f"[Warning] Extra columns detected: {extra}")
 
 
+_BOUNDED_UNIT_COLUMNS = (
+    "danceability",
+    "energy",
+    "valence",
+    "acousticness",
+    "instrumentalness",
+    "speechiness",
+)
+
+_POSITIVE_COLUMNS = ("tempo", "duration_ms")
+
+
 def validate_ranges(df: pd.DataFrame) -> None:
     errors = []
 
@@ -43,12 +55,8 @@ def validate_ranges(df: pd.DataFrame) -> None:
         if not df[col].dropna().between(low, high).all():
             errors.append(f"{col} out of range [{low}, {high}]")
 
-    check_range("danceability", 0, 1)
-    check_range("energy", 0, 1)
-    check_range("valence", 0, 1)
-    check_range("acousticness", 0, 1)
-    check_range("instrumentalness", 0, 1)
-    check_range("speechiness", 0, 1)
+    for col in _BOUNDED_UNIT_COLUMNS:
+        check_range(col, 0, 1)
 
     if (df["tempo"] <= 0).any():
         errors.append("tempo contains non-positive values")
@@ -58,6 +66,30 @@ def validate_ranges(df: pd.DataFrame) -> None:
 
     if errors:
         raise ValueError("Range validation failed:\n" + "\n".join(errors))
+
+
+def range_violation_counts(df: pd.DataFrame) -> dict[str, int]:
+    """Count out-of-range values per column without raising.
+
+    Parallels :func:`validate_ranges` but returns per-column counts so the
+    validation entrypoint can report on real-world datasets that contain
+    a handful of dirty rows (e.g. ``tempo == 0``) without aborting.
+    """
+    counts: dict[str, int] = {}
+
+    for col in _BOUNDED_UNIT_COLUMNS:
+        if col not in df.columns:
+            continue
+        series = df[col].dropna()
+        counts[col] = int((~series.between(0, 1)).sum())
+
+    for col in _POSITIVE_COLUMNS:
+        if col not in df.columns:
+            continue
+        series = df[col].dropna()
+        counts[col] = int((series <= 0).sum())
+
+    return counts
 
 
 def validate_duplicates(df: pd.DataFrame) -> dict:
@@ -100,6 +132,7 @@ def validation_report(df: pd.DataFrame) -> dict:
     report.update(validate_duplicates(df))
     report["unique_tracks"] = int(df["track_id"].nunique())
     report["inconsistent_tracks"] = validate_track_consistency(df)
+    report["range_violations"] = range_violation_counts(df)
 
     return report
 
@@ -110,7 +143,6 @@ def run_validation(path: str):
     df = load_data(path)
 
     validate_schema(df)
-    validate_ranges(df)
     validate_correlations(df)
 
     report = validation_report(df)

--- a/tests/test_preference.py
+++ b/tests/test_preference.py
@@ -87,6 +87,29 @@ class TestAddSongs:
         with pytest.raises(ValueError, match="No track named"):
             liked.add_by_name("Nonexistent Song")
 
+    def test_add_by_name_handles_regex_metacharacters_in_artist(self) -> None:
+        """Artist names with regex metachars must be matched as literal substrings."""
+        df = make_df().copy()
+        df.loc[df["track_id"] == "t2", "artists"] = "Some Band (Live)"
+        liked = LikedSongs(df)
+
+        # An unbalanced "(" in a regex would raise a PatternError;
+        # using it as a literal substring is the correct behavior.
+        liked.add_by_name("Song B", artist="(Live)")
+
+        assert "t2" in liked.liked_ids
+
+    def test_add_by_name_handles_nan_in_name_and_artist_columns(self) -> None:
+        """Missing text values must not break the fuzzy match."""
+        df = make_df().copy()
+        df.loc[df["track_id"] == "t1", "track_name"] = None
+        df.loc[df["track_id"] == "t1", "artists"] = None
+        liked = LikedSongs(df)
+
+        liked.add_by_name("Song B", artist="Artist B")
+
+        assert "t2" in liked.liked_ids
+
     def test_remove(self) -> None:
         liked = LikedSongs(make_df())
         liked.add_by_id("t1")
@@ -203,6 +226,43 @@ class TestPredict:
         expected_cols = ["track_id", "track_name", "artists", "track_genre",
                          "popularity", "preference_score"]
         assert list(scores.columns) == expected_cols
+
+    def test_predict_deduplicates_same_song_across_genres(self) -> None:
+        """The Spotify dataset stores one row per (song, genre); dedupe by default."""
+        df = pd.DataFrame([
+            make_row(track_id="t1", track_name="Song A", artists="Artist A",
+                     danceability=0.3, energy=0.4, tempo=100.0),
+            # Same song tagged under two genres — distinct track_ids.
+            make_row(track_id="t2a", track_name="Hit", artists="Star",
+                     track_genre="pop", danceability=0.7, energy=0.9, tempo=140.0),
+            make_row(track_id="t2b", track_name="Hit", artists="Star",
+                     track_genre="dance", danceability=0.7, energy=0.9, tempo=140.0),
+        ])
+        liked = LikedSongs(df)
+        liked.add_by_id("t1")
+
+        scores = liked.predict()
+
+        hit_rows = scores[scores["track_name"] == "Hit"]
+        assert len(hit_rows) == 1
+
+    def test_predict_keeps_duplicates_when_disabled(self) -> None:
+        """`deduplicate=False` preserves one row per track_id."""
+        df = pd.DataFrame([
+            make_row(track_id="t1", track_name="Song A", artists="Artist A",
+                     danceability=0.3, energy=0.4, tempo=100.0),
+            make_row(track_id="t2a", track_name="Hit", artists="Star",
+                     track_genre="pop", danceability=0.7, energy=0.9, tempo=140.0),
+            make_row(track_id="t2b", track_name="Hit", artists="Star",
+                     track_genre="dance", danceability=0.7, energy=0.9, tempo=140.0),
+        ])
+        liked = LikedSongs(df)
+        liked.add_by_id("t1")
+
+        scores = liked.predict(deduplicate=False)
+
+        hit_rows = scores[scores["track_name"] == "Hit"]
+        assert len(hit_rows) == 2
 
 
 class TestBuildProfile:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -13,6 +13,7 @@ import pytest
 
 from unwrapped.validation import EXPECTED_COLUMNS
 from unwrapped.validation import missing_summary
+from unwrapped.validation import range_violation_counts
 from unwrapped.validation import run_validation
 from unwrapped.validation import validate_correlations
 from unwrapped.validation import validate_duplicates
@@ -179,6 +180,46 @@ def test_validate_ranges_rejects_non_missing_out_of_range_values() -> None:
         validate_ranges(df)
 
     assert "energy out of range [0, 1]" in str(exc_info.value)
+
+
+def test_range_violation_counts_reports_per_column_without_raising() -> None:
+    """Soft range reporting should count dirty rows instead of aborting."""
+
+    df = pd.DataFrame(
+        [
+            make_valid_row(track_id="track-1"),
+            make_valid_row(track_id="track-2", tempo=0, duration_ms=0),
+            make_valid_row(track_id="track-3", danceability=1.5, energy=-0.1),
+        ]
+    )
+
+    counts = range_violation_counts(df)
+
+    assert counts["tempo"] == 1
+    assert counts["duration_ms"] == 1
+    assert counts["danceability"] == 1
+    assert counts["energy"] == 1
+    # Clean columns should report zero — not be missing from the dict.
+    assert counts["valence"] == 0
+
+
+def test_run_validation_reports_range_violations_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`run_validation` must not abort when the raw data has dirty rows."""
+
+    df = pd.DataFrame(
+        [
+            make_valid_row(track_id="track-1"),
+            make_valid_row(track_id="track-2", tempo=0),
+        ]
+    )
+
+    monkeypatch.setattr("unwrapped.io.load_data", lambda _path: df)
+
+    _, report = run_validation("fake/path.csv")
+
+    assert report["range_violations"]["tempo"] == 1
 
 
 def test_validate_duplicates_counts_both_row_and_track_id_duplicates() -> None:


### PR DESCRIPTION
## Summary

Two runtime bugs that surface only against the real dataset:

- `run_validation()` aborted on observed `tempo <= 0` / `duration_ms <= 0` rows, so `demo_validation.py` crashed out of the box. Range checks now report per-column counts via `range_violations` in the report. Strict `validate_ranges` kept for callers that want a hard gate.
- `LikedSongs.add_by_name(..., artist=...)` forwarded the artist into `str.contains` as a regex — parens/dots in names either raised `PatternError` or matched wrong rows. Now matched as a literal substring, NaN-safe.
- `LikedSongs.predict()` top-N was dominated by duplicates (same song under multiple genres = distinct `track_id`s). New `deduplicate=True` default collapses on `(track_name, artists)` keeping the highest-scoring row.

## Test plan

- [x] `pytest` — 199 passed (193 baseline + 6 new)
- [x] `demo_validation.py` runs end-to-end and reports `tempo: 157, duration_ms: 1`
- [x] `demo_preference.py` returns 10 distinct songs in the top 10
- [x] All other demo scripts still run clean