### PR TITLE
Add statistical inference layer to popularity correlations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "pandas>=2.2",
   "matplotlib>=3.8",
   "scikit-learn>=1.4",
+  "scipy>=1.11",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy>=2.0
 pandas>=2.2
 matplotlib>=3.8
 scikit-learn>=1.4
+scipy>=1.11
 
 # Dev / test
 pytest>=8.0

--- a/scripts/demo_analysis.py
+++ b/scripts/demo_analysis.py
@@ -51,7 +51,20 @@ def main():
     )
 
     corr = results["correlations"]
-    print(corr[["feature", "correlation", "strength"]].to_string(index=False))
+
+    display = corr.copy()
+    display["95% CI"] = display.apply(
+        lambda row: f"[{row['ci_low']:+.3f}, {row['ci_high']:+.3f}]", axis=1
+    )
+    display["p (Holm)"] = display["p_value_adjusted"].map(
+        lambda p: "<1e-4" if p < 1e-4 else f"{p:.4f}"
+    )
+    display["sig"] = display["significant"].map(lambda s: "✓" if s else "·")
+    print(
+        display[
+            ["feature", "correlation", "95% CI", "p (Holm)", "sig", "strength"]
+        ].to_string(index=False)
+    )
 
     top = corr.iloc[0]
     second = corr.iloc[1]
@@ -60,9 +73,19 @@ def main():
     print(f"\nFindings:")
     print(
         f"  The strongest predictor of popularity is {top['feature']} "
-        f"(r = {top['correlation']:+.4f}, {top['strength']}), followed by "
+        f"(r = {top['correlation']:+.4f}, 95% CI "
+        f"[{top['ci_low']:+.3f}, {top['ci_high']:+.3f}], "
+        f"Holm-adj. p = "
+        f"{'<1e-4' if top['p_value_adjusted'] < 1e-4 else f'{top['p_value_adjusted']:.4f}'}"
+        f"), followed by "
         f"{second['feature']} (r = {second['correlation']:+.4f}) and "
         f"{third['feature']} (r = {third['correlation']:+.4f})."
+    )
+
+    n_significant = int(corr["significant"].sum())
+    print(
+        f"  {n_significant} of {len(corr)} features stay significant "
+        f"after Holm–Bonferroni correction."
     )
 
     # Check direction patterns

--- a/scripts/demo_visualization.py
+++ b/scripts/demo_visualization.py
@@ -4,6 +4,7 @@ from unwrapped.clean import clean_data
 from unwrapped.io import load_data
 from unwrapped.visualization import (
     plot_audio_heatmap,
+    plot_correlation_forest,
     plot_feature_correlations,
     plot_genre_popularity,
     plot_hit_vs_nonhit_profiles,
@@ -33,6 +34,10 @@ def main() -> None:
     fig3, _ = plot_feature_correlations(df)
     save_figure(fig3, output_dir / "feature_correlations.png")
     print("Saved outputs/feature_correlations.png")
+
+    fig3b, _ = plot_correlation_forest(df)
+    save_figure(fig3b, output_dir / "feature_correlations_forest.png")
+    print("Saved outputs/feature_correlations_forest.png")
 
     fig4, _ = plot_genre_popularity(df, top_n=15)
     save_figure(fig4, output_dir / "genre_popularity.png")

--- a/src/unwrapped/analysis.py
+++ b/src/unwrapped/analysis.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+from scipy import stats
 
 from .constants import AUDIO_FEATURES
 from .io import load_data
@@ -164,37 +165,134 @@ def find_genre_outliers(
 # ---------------------------------------------------------------------------
 
 
-def analyze_popularity_correlations(df: pd.DataFrame) -> pd.DataFrame:
+def _bootstrap_correlation_ci(
+    x: np.ndarray,
+    y: np.ndarray,
+    n_bootstrap: int,
+    alpha: float,
+    rng: np.random.Generator,
+) -> tuple[float, float]:
+    """Percentile-bootstrap confidence interval for Pearson r.
+
+    Resamples (x, y) pairs with replacement ``n_bootstrap`` times and
+    returns the central ``1 - alpha`` interval of the resampled r values.
+    Returns ``(nan, nan)`` when ``n_bootstrap`` is zero or every resample
+    degenerates (e.g. a constant feature).
+    """
+    if n_bootstrap <= 0:
+        return float("nan"), float("nan")
+
+    n = len(x)
+    samples = np.empty(n_bootstrap, dtype=float)
+    for i in range(n_bootstrap):
+        idx = rng.integers(0, n, size=n)
+        xb = x[idx]
+        yb = y[idx]
+        # Skip resamples where one side is constant; corrcoef would warn
+        # and return NaN, which nanpercentile handles downstream.
+        if xb.std() == 0 or yb.std() == 0:
+            samples[i] = np.nan
+        else:
+            samples[i] = np.corrcoef(xb, yb)[0, 1]
+
+    if np.all(np.isnan(samples)):
+        return float("nan"), float("nan")
+
+    lower = float(np.nanpercentile(samples, 100 * alpha / 2))
+    upper = float(np.nanpercentile(samples, 100 * (1 - alpha / 2)))
+    return lower, upper
+
+
+def _holm_bonferroni(p_values: np.ndarray) -> np.ndarray:
+    """Holm step-down adjustment for a family of p-values.
+
+    Returns adjusted p-values in the same order as the input. NaN inputs
+    are left as NaN and excluded from the correction (they don't count
+    toward the family size).
+    """
+    p = np.asarray(p_values, dtype=float)
+    adjusted = np.full_like(p, np.nan)
+    tested_mask = ~np.isnan(p)
+    tested = p[tested_mask]
+
+    if tested.size == 0:
+        return adjusted
+
+    order = np.argsort(tested)
+    ranked = tested[order]
+    factors = np.arange(tested.size, 0, -1)  # m, m-1, ..., 1
+    raw = ranked * factors
+    monotone = np.maximum.accumulate(raw)
+    capped = np.minimum(monotone, 1.0)
+
+    back = np.empty_like(tested)
+    back[order] = capped
+    adjusted[tested_mask] = back
+    return adjusted
+
+
+def analyze_popularity_correlations(
+    df: pd.DataFrame,
+    n_bootstrap: int = 1000,
+    alpha: float = 0.05,
+    random_state: int | None = 42,
+) -> pd.DataFrame:
     """Compute Pearson correlations between each audio feature and popularity.
 
-    Uses ``np.corrcoef`` and classifies each correlation by strength.
+    Each correlation is reported with a two-sided p-value, a percentile
+    bootstrap confidence interval, a Holm–Bonferroni-adjusted p-value
+    to account for testing nine features simultaneously, and a strength
+    label for quick scanning.
 
     Parameters
     ----------
     df : pd.DataFrame
         Spotify dataset with ``popularity`` and audio feature columns.
+    n_bootstrap : int, default 1000
+        Bootstrap resamples used to build the confidence interval. Set
+        to ``0`` to skip the bootstrap (``ci_low``/``ci_high`` become NaN).
+    alpha : float, default 0.05
+        Significance level. Controls both the CI width (``1 - alpha``)
+        and the ``significant`` column after Holm adjustment.
+    random_state : int or None, default 42
+        Seed for the bootstrap resampler. ``None`` uses fresh entropy.
 
     Returns
     -------
     pd.DataFrame
-        One row per feature with correlation value, absolute value,
-        direction, and strength label.  Sorted by absolute correlation
-        descending.
+        One row per feature with columns ``feature``, ``correlation``,
+        ``abs_correlation``, ``direction``, ``strength``, ``ci_low``,
+        ``ci_high``, ``p_value``, ``p_value_adjusted``, ``significant``.
+        Sorted by absolute correlation descending.
     """
 
     popularity = df["popularity"].values.astype(float)
-    results = []
+    rng = np.random.default_rng(random_state)
+    rows: list[dict[str, object]] = []
 
     for feature in AUDIO_FEATURES:
         feature_vals = df[feature].values.astype(float)
 
-        # Drop rows where either value is NaN
         valid = ~(np.isnan(popularity) | np.isnan(feature_vals))
-        if np.sum(valid) < 2:
+        if np.sum(valid) < 3:
             continue
 
-        corr = np.corrcoef(popularity[valid], feature_vals[valid])[0, 1]
+        x = popularity[valid]
+        y = feature_vals[valid]
+
+        # Skip constant columns: scipy.stats.pearsonr would warn and
+        # return NaN, and the bootstrap CI would be meaningless.
+        if x.std() == 0 or y.std() == 0:
+            continue
+
+        pearson = stats.pearsonr(x, y)
+        corr = float(pearson.statistic)
+        p_value = float(pearson.pvalue)
         abs_corr = float(np.abs(corr))
+
+        ci_low, ci_high = _bootstrap_correlation_ci(
+            x, y, n_bootstrap=n_bootstrap, alpha=alpha, rng=rng
+        )
 
         if abs_corr >= 0.7:
             strength = "strong"
@@ -205,15 +303,33 @@ def analyze_popularity_correlations(df: pd.DataFrame) -> pd.DataFrame:
         else:
             strength = "very weak"
 
-        results.append({
+        rows.append({
             "feature": feature,
-            "correlation": round(float(corr), 4),
+            "correlation": round(corr, 4),
             "abs_correlation": round(abs_corr, 4),
             "direction": "positive" if corr > 0 else "negative",
             "strength": strength,
+            "ci_low": round(ci_low, 4) if not np.isnan(ci_low) else np.nan,
+            "ci_high": round(ci_high, 4) if not np.isnan(ci_high) else np.nan,
+            "p_value": p_value,
+            "n": int(valid.sum()),
         })
 
-    result_df = pd.DataFrame(results)
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "feature", "correlation", "abs_correlation", "direction",
+                "strength", "ci_low", "ci_high", "p_value",
+                "p_value_adjusted", "significant", "n",
+            ]
+        )
+
+    result_df = pd.DataFrame(rows)
+
+    adjusted = _holm_bonferroni(result_df["p_value"].to_numpy())
+    result_df["p_value_adjusted"] = adjusted
+    result_df["significant"] = result_df["p_value_adjusted"] < alpha
+
     return result_df.sort_values(
         "abs_correlation", ascending=False
     ).reset_index(drop=True)

--- a/src/unwrapped/visualization.py
+++ b/src/unwrapped/visualization.py
@@ -91,6 +91,82 @@ def plot_feature_correlations(df: pd.DataFrame):
     return fig, ax
 
 
+def plot_correlation_forest(
+    df: pd.DataFrame,
+    n_bootstrap: int = 1000,
+    alpha: float = 0.05,
+    random_state: int | None = 42,
+):
+    """
+    Forest plot of each audio feature's Pearson correlation with popularity,
+    annotated with bootstrap confidence intervals and Holm-adjusted significance.
+
+    Features that remain significant after the Holm–Bonferroni correction are
+    drawn in the series color; non-significant features are drawn in grey so
+    they're visually deprioritized.
+    """
+    from .analysis import analyze_popularity_correlations
+
+    corr_df = analyze_popularity_correlations(
+        df,
+        n_bootstrap=n_bootstrap,
+        alpha=alpha,
+        random_state=random_state,
+    )
+    if corr_df.empty:
+        raise ValueError("No features available for correlation forest plot.")
+
+    # Draw strongest |r| at the top so the eye moves down-then-weaker.
+    corr_df = corr_df.sort_values("abs_correlation", ascending=True).reset_index(
+        drop=True
+    )
+
+    y_pos = np.arange(len(corr_df))
+    r = corr_df["correlation"].to_numpy()
+    lo = corr_df["ci_low"].to_numpy()
+    hi = corr_df["ci_high"].to_numpy()
+    xerr = np.vstack([r - lo, hi - r])
+
+    significant = corr_df["significant"].fillna(False).to_numpy()
+    colors = np.where(significant, "#1DB954", "#b3b3b3")
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    for i in range(len(corr_df)):
+        ax.errorbar(
+            r[i],
+            y_pos[i],
+            xerr=np.array([[xerr[0, i]], [xerr[1, i]]]),
+            fmt="o",
+            color=colors[i],
+            ecolor=colors[i],
+            capsize=4,
+            markersize=6,
+            linewidth=1.5,
+        )
+
+    ax.axvline(0, color="black", linewidth=0.8)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(corr_df["feature"])
+    ax.set_xlabel("Pearson r with popularity (bootstrap 95% CI)")
+    ax.set_title(
+        f"Audio Feature Correlations with Popularity "
+        f"(Holm-adjusted α = {alpha:g})"
+    )
+
+    # Legend explaining the color split without relying on a plot artist.
+    from matplotlib.lines import Line2D
+    handles = [
+        Line2D([0], [0], marker="o", color="#1DB954", linestyle="",
+               label="significant"),
+        Line2D([0], [0], marker="o", color="#b3b3b3", linestyle="",
+               label="not significant"),
+    ]
+    ax.legend(handles=handles, loc="lower right", frameon=False)
+    fig.tight_layout()
+
+    return fig, ax
+
+
 def plot_genre_popularity(df: pd.DataFrame, top_n: int = 15):
     """
     Bar chart of mean popularity score for the top N genres by track count.

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -10,6 +10,7 @@ import pytest
 
 from unwrapped.analysis import (
     AUDIO_FEATURES,
+    _holm_bonferroni,
     analyze_popularity_correlations,
     compare_genres,
     compute_genre_deviations,
@@ -232,6 +233,110 @@ class TestAnalyzePopularityCorrelations:
 
         valid = {"strong", "moderate", "weak", "very weak"}
         assert set(result["strength"]).issubset(valid)
+
+    def test_inference_columns_are_present(self) -> None:
+        result = analyze_popularity_correlations(make_df(), n_bootstrap=100)
+
+        for col in (
+            "ci_low",
+            "ci_high",
+            "p_value",
+            "p_value_adjusted",
+            "significant",
+            "n",
+        ):
+            assert col in result.columns
+
+    def test_confidence_interval_brackets_the_point_estimate(self) -> None:
+        result = analyze_popularity_correlations(
+            make_df(), n_bootstrap=200, random_state=0
+        )
+
+        for _, row in result.iterrows():
+            assert row["ci_low"] <= row["correlation"] <= row["ci_high"]
+
+    def test_bootstrap_disabled_returns_nan_ci(self) -> None:
+        result = analyze_popularity_correlations(make_df(), n_bootstrap=0)
+
+        assert result["ci_low"].isna().all()
+        assert result["ci_high"].isna().all()
+        # p-values come from scipy, not the bootstrap, so they should still exist.
+        assert result["p_value"].notna().all()
+
+    def test_holm_adjusted_pvalues_are_not_smaller_than_raw(self) -> None:
+        result = analyze_popularity_correlations(make_df(), n_bootstrap=50)
+
+        assert (
+            result["p_value_adjusted"].fillna(0) >= result["p_value"].fillna(0)
+        ).all()
+        assert (result["p_value_adjusted"].dropna() <= 1.0).all()
+
+    def test_significance_flag_follows_alpha_threshold(self) -> None:
+        result = analyze_popularity_correlations(
+            make_df(), n_bootstrap=50, alpha=0.01
+        )
+
+        assert (
+            result["significant"] == (result["p_value_adjusted"] < 0.01)
+        ).all()
+
+    def test_alpha_controls_ci_width(self) -> None:
+        narrow = analyze_popularity_correlations(
+            make_df(), n_bootstrap=400, alpha=0.20, random_state=1
+        )
+        wide = analyze_popularity_correlations(
+            make_df(), n_bootstrap=400, alpha=0.01, random_state=1
+        )
+
+        narrow_width = (narrow["ci_high"] - narrow["ci_low"]).mean()
+        wide_width = (wide["ci_high"] - wide["ci_low"]).mean()
+
+        # A larger (1 - alpha) coverage should produce a wider interval on
+        # average.
+        assert wide_width >= narrow_width
+
+    def test_random_state_makes_ci_deterministic(self) -> None:
+        first = analyze_popularity_correlations(
+            make_df(), n_bootstrap=100, random_state=7
+        )
+        second = analyze_popularity_correlations(
+            make_df(), n_bootstrap=100, random_state=7
+        )
+
+        np.testing.assert_array_equal(
+            first["ci_low"].to_numpy(), second["ci_low"].to_numpy()
+        )
+        np.testing.assert_array_equal(
+            first["ci_high"].to_numpy(), second["ci_high"].to_numpy()
+        )
+
+
+class TestHolmBonferroni:
+    def test_textbook_example(self) -> None:
+        """Worked example: Holm on four p-values with a known adjustment."""
+        raw = np.array([0.01, 0.04, 0.03, 0.005])
+        adjusted = _holm_bonferroni(raw)
+
+        # Sorted ascending: [0.005, 0.01, 0.03, 0.04] with factors [4,3,2,1]
+        # -> [0.02, 0.03, 0.06, 0.04] -> monotone [0.02, 0.03, 0.06, 0.06].
+        # Unsort to original order: [0.03, 0.06, 0.06, 0.02].
+        expected = np.array([0.03, 0.06, 0.06, 0.02])
+        np.testing.assert_allclose(adjusted, expected, atol=1e-12)
+
+    def test_caps_at_one(self) -> None:
+        adjusted = _holm_bonferroni(np.array([0.5, 0.8, 0.9]))
+
+        assert (adjusted <= 1.0).all()
+
+    def test_preserves_nan(self) -> None:
+        adjusted = _holm_bonferroni(np.array([0.01, np.nan, 0.2]))
+
+        # The NaN entry stays NaN and does not count toward the family size.
+        assert np.isnan(adjusted[1])
+        # The remaining two are the family m = 2.
+        np.testing.assert_allclose(
+            adjusted[[0, 2]], np.array([0.02, 0.2]), atol=1e-12
+        )
 
 
 # ------------------------------------------------------------------

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -9,6 +9,7 @@ import pytest
 
 from unwrapped.visualization import (
     plot_audio_heatmap,
+    plot_correlation_forest,
     plot_feature_correlations,
     plot_genre_popularity,
     plot_hit_vs_nonhit_profiles,
@@ -88,6 +89,14 @@ def test_plot_feature_correlations_raises_on_missing_column():
     df = pd.DataFrame({"popularity": [90, 80]})
     with pytest.raises(ValueError, match="missing columns"):
         plot_feature_correlations(df)
+
+
+def test_plot_correlation_forest_runs():
+    fig, ax = plot_correlation_forest(
+        _sample_df(), n_bootstrap=50, random_state=0
+    )
+    assert fig is not None
+    assert ax is not None
 
 
 def test_plot_genre_popularity_runs():


### PR DESCRIPTION
## Summary

The popularity-correlation table reported only point estimates and heuristic "strong/moderate/weak" labels — not enough to defend any claim in the research-question writeup. Each feature now ships with:

- **Two-sided Pearson p-value** via `scipy.stats.pearsonr`
- **Percentile-bootstrap 95% CI** (configurable `n_bootstrap`, `alpha`, `random_state`; default 1000 resamples, seed 42)
- **Holm–Bonferroni adjusted p-value** across the nine-feature family
- **`significant` flag** gated on the adjusted p-value
- **`n`** — actual sample size after NaN filtering

New `plot_correlation_forest` renders the same information as an error-bar forest plot, greying out features that don't survive the correction.

## On the real dataset

All 9 audio features stay significant after Holm correction (p < 0.01 each). `instrumentalness` is the strongest at r = −0.1287, 95% CI [−0.135, −0.123] — "weak but real" is now a defensible claim, not a label.

## Test plan

- [x] `pytest` — 210 passed (199 baseline + 11 new)
- [x] Holm helper verified against a worked textbook example and NaN handling
- [x] CI brackets the point estimate, widens with smaller α, deterministic under fixed seed
- [x] `demo_analysis.py` prints the inference columns end-to-end
- [x] `demo_visualization.py` writes `outputs/feature_correlations_forest.png`