### PR TITLE
Add CLI dataset path support and stabilize cross-validation

### DIFF
--- a/src/unwrapped/popularity.py
+++ b/src/unwrapped/popularity.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import argparse
 
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression
@@ -434,18 +435,29 @@ def run_popularity_pipeline(
     }
 
 
-def main() -> None:
-    data_path = "data/raw/spotify_data.csv"
+import sys
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the Spotify popularity prediction pipeline."
+    )
+    parser.add_argument(
+        "data_path",
+        nargs="?",
+        default="data/raw/spotify_data.csv",
+        help="Path to the Spotify dataset CSV.",
+    )
+
+    args = parser.parse_args(argv if argv is not None else [])
+
     try:
-        run_popularity_pipeline(data_path)
+        run_popularity_pipeline(args.data_path)
     except FileNotFoundError:
         print(
-            f"Error: data file not found at '{data_path}'.\n"
-            "Make sure you are running this script from the repository root\n"
-            "and that the Spotify dataset has been placed at data/raw/spotify_data.csv."
+            f"Error: data file not found at '{args.data_path}'.\n"
+            "Provide a valid dataset path as a command-line argument or place "
+            "the dataset in data/raw/spotify_data.csv."
         )
         raise SystemExit(1)
-
-
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
This PR improves the robustness and usability of the popularity module.

First, it adds support for passing a dataset path as a command-line argument. The pipeline now defaults to data/raw/spotify_data.csv, but users can optionally provide a custom dataset path when running the module. This makes the script more flexible and easier to use across different environments.

Second, it updates cross-validation to use n_jobs=1 instead of n_jobs=-1. This change improves test stability and reproducibility, particularly on Windows/Python environments where parallel execution via joblib can cause worker process failures. This does not affect model logic or evaluation results, only execution reliability.

All existing functionality remains unchanged, and the full test suite passes successfully.