### PR TITLE
New Predictive Modeling Features

### DIFF
--- a/src/unwrapped/clustering.py
+++ b/src/unwrapped/clustering.py
@@ -1,0 +1,245 @@
+"""Unsupervised clustering of Spotify tracks by audio profile.
+
+Provides utilities to scale features, search for a good ``k`` (elbow +
+silhouette), fit a ``KMeans`` model, recover centroids in original feature
+units, and summarize each cluster.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+from sklearn.preprocessing import StandardScaler
+
+from .constants import AUDIO_FEATURES
+from .io import load_data
+
+
+SILHOUETTE_SAMPLE_SIZE = 2000
+
+
+def prepare_clustering_data(
+    df: pd.DataFrame,
+    features: list[str] | None = None,
+) -> tuple[np.ndarray, StandardScaler, list[str], pd.Index]:
+    """Drop NA rows on the chosen features and standard-scale them.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataset.
+    features : list[str], optional
+        Columns to cluster on. Defaults to :data:`AUDIO_FEATURES`.
+
+    Returns
+    -------
+    tuple
+        ``(X_scaled, scaler, feature_names, kept_index)`` — the kept index
+        lets callers re-attach cluster labels to the original frame.
+    """
+    if features is None:
+        features = list(AUDIO_FEATURES)
+
+    missing = [c for c in features if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+    subset = df[features].apply(pd.to_numeric, errors="coerce").dropna()
+    if subset.empty:
+        raise ValueError("No rows with non-null values for the chosen features.")
+
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(subset.to_numpy())
+
+    return X_scaled, scaler, features, subset.index
+
+
+def find_optimal_k(
+    X_scaled: np.ndarray,
+    k_range: Iterable[int] = range(2, 11),
+    random_state: int = 42,
+) -> pd.DataFrame:
+    """Sweep ``k`` and report inertia (elbow) and silhouette per value.
+
+    Silhouette is computed on a 2000-row sample for speed when
+    ``len(X_scaled) > SILHOUETTE_SAMPLE_SIZE``.
+    """
+    rows = []
+    rng = np.random.default_rng(random_state)
+    n = len(X_scaled)
+    sample_idx = (
+        rng.choice(n, size=SILHOUETTE_SAMPLE_SIZE, replace=False)
+        if n > SILHOUETTE_SAMPLE_SIZE
+        else np.arange(n)
+    )
+
+    for k in k_range:
+        model = KMeans(n_clusters=k, n_init=10, random_state=random_state)
+        labels = model.fit_predict(X_scaled)
+        sample_labels = labels[sample_idx]
+        if len(np.unique(sample_labels)) < 2:
+            silhouette = float("nan")
+        else:
+            silhouette = float(silhouette_score(X_scaled[sample_idx], sample_labels))
+
+        rows.append(
+            {
+                "k": int(k),
+                "inertia": float(model.inertia_),
+                "silhouette": silhouette,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def cluster_songs(
+    df: pd.DataFrame,
+    n_clusters: int = 5,
+    features: list[str] | None = None,
+    random_state: int = 42,
+) -> tuple[pd.DataFrame, KMeans, StandardScaler]:
+    """Fit a KMeans model and attach a ``cluster`` column to ``df``.
+
+    Rows missing any of the chosen features get ``cluster = -1`` so the
+    returned frame keeps the same row count as the input.
+    """
+    X_scaled, scaler, feature_names, kept_index = prepare_clustering_data(
+        df, features=features
+    )
+
+    model = KMeans(n_clusters=n_clusters, n_init=10, random_state=random_state)
+    labels = model.fit_predict(X_scaled)
+
+    out = df.copy()
+    out["cluster"] = -1
+    out.loc[kept_index, "cluster"] = labels
+    return out, model, scaler
+
+
+def cluster_centroids(
+    model: KMeans, scaler: StandardScaler, feature_names: list[str]
+) -> pd.DataFrame:
+    """Return centroids in original (unscaled) feature units."""
+    centroids = scaler.inverse_transform(model.cluster_centers_)
+    return pd.DataFrame(
+        centroids,
+        columns=feature_names,
+        index=pd.Index(range(len(centroids)), name="cluster"),
+    )
+
+
+def cluster_summary(
+    df_with_clusters: pd.DataFrame,
+    features: list[str] | None = None,
+) -> pd.DataFrame:
+    """Per-cluster size, mean popularity, mean of each feature, and top genre."""
+    if features is None:
+        features = list(AUDIO_FEATURES)
+
+    clustered = df_with_clusters[df_with_clusters["cluster"] >= 0]
+
+    rows = []
+    for cluster_id, group in clustered.groupby("cluster"):
+        row: dict[str, Any] = {
+            "cluster": int(cluster_id),
+            "size": len(group),
+        }
+        if "popularity" in group.columns:
+            row["mean_popularity"] = float(group["popularity"].mean())
+        for feat in features:
+            if feat in group.columns:
+                row[f"mean_{feat}"] = float(group[feat].mean())
+        if "track_genre" in group.columns and not group["track_genre"].dropna().empty:
+            row["top_genre"] = group["track_genre"].mode().iloc[0]
+        rows.append(row)
+
+    return pd.DataFrame(rows).sort_values("cluster").reset_index(drop=True)
+
+
+def save_outputs(
+    assignments_df: pd.DataFrame,
+    centroids_df: pd.DataFrame,
+    summary_df: pd.DataFrame,
+    k_search_df: pd.DataFrame | None,
+    output_dir: str | Path = "outputs",
+) -> dict[str, str]:
+    """Write clustering artifacts to ``output_dir``."""
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    paths = {
+        "assignments": output_path / "cluster_assignments.csv",
+        "centroids": output_path / "cluster_centroids.csv",
+        "summary": output_path / "cluster_summary.csv",
+    }
+
+    assignments_df.to_csv(paths["assignments"], index=False)
+    centroids_df.to_csv(paths["centroids"])
+    summary_df.to_csv(paths["summary"], index=False)
+
+    if k_search_df is not None:
+        k_path = output_path / "cluster_k_search.csv"
+        k_search_df.to_csv(k_path, index=False)
+        paths["k_search"] = k_path
+
+    return {k: str(v) for k, v in paths.items()}
+
+
+def run_clustering_pipeline(
+    data_path: str = "data/raw/spotify_data.csv",
+    n_clusters: int = 5,
+    k_search_range: Iterable[int] | None = range(2, 11),
+    save_results: bool = True,
+    output_dir: str | Path = "outputs",
+) -> dict[str, Any]:
+    """End-to-end pipeline: load, prep, search k (optional), cluster, summarize."""
+    df = load_data(data_path)
+
+    X_scaled, scaler, feature_names, kept_index = prepare_clustering_data(df)
+
+    k_search_df = (
+        find_optimal_k(X_scaled, k_range=k_search_range)
+        if k_search_range is not None
+        else None
+    )
+
+    df_with_clusters, model, _ = cluster_songs(df, n_clusters=n_clusters)
+    centroids_df = cluster_centroids(model, scaler, feature_names)
+    summary_df = cluster_summary(df_with_clusters)
+
+    assignments_cols = [c for c in ("track_id", "track_name", "artists", "track_genre") if c in df_with_clusters.columns]
+    assignments_df = df_with_clusters.loc[df_with_clusters["cluster"] >= 0, assignments_cols + ["cluster"]]
+
+    if save_results:
+        save_outputs(
+            assignments_df,
+            centroids_df,
+            summary_df,
+            k_search_df,
+            output_dir=output_dir,
+        )
+
+    return {
+        "model": model,
+        "scaler": scaler,
+        "assignments": assignments_df,
+        "centroids": centroids_df,
+        "summary": summary_df,
+        "k_search": k_search_df,
+    }
+
+
+def main() -> None:
+    """Run the default clustering pipeline."""
+    run_clustering_pipeline("data/raw/spotify_data.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unwrapped/genre_classifier.py
+++ b/src/unwrapped/genre_classifier.py
@@ -1,0 +1,282 @@
+"""Multi-class genre classifier for Spotify tracks.
+
+Predicts ``track_genre`` from audio features. Mirrors the structure of
+:mod:`unwrapped.hit_shape_predictor` so the project stays internally
+consistent: validate, prepare, split, train, evaluate, compare, save.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score, confusion_matrix, f1_score
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from .constants import AUDIO_FEATURES_FOR_HIT_CLASSIFICATION
+from .io import load_data
+
+
+REQUIRED_COLUMNS: list[str] = AUDIO_FEATURES_FOR_HIT_CLASSIFICATION + ["track_genre"]
+
+RF_PARAMS: dict = {
+    "n_estimators": 300,
+    "max_features": "sqrt",
+    "random_state": 42,
+    "n_jobs": -1,
+    "class_weight": "balanced",
+}
+
+LR_PARAMS: dict = {
+    "max_iter": 1000,
+    "random_state": 42,
+    "class_weight": "balanced",
+    "solver": "lbfgs",
+}
+
+
+def validate_data(df: pd.DataFrame) -> None:
+    """Validate that ``df`` is non-empty and has the audio features + genre."""
+    if df.empty:
+        raise ValueError("Input dataframe is empty.")
+
+    missing = [c for c in REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+
+
+def prepare_genre_data(
+    df: pd.DataFrame, min_samples_per_genre: int = 50
+) -> tuple[pd.DataFrame, pd.Series]:
+    """Drop rare genres, coerce dtypes, and return feature matrix + target.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Validated dataset.
+    min_samples_per_genre : int, default 50
+        Genres with fewer rows than this are removed (they hurt stratified
+        splits and macro-F1).
+
+    Returns
+    -------
+    tuple
+        ``(X, y)`` ready for ``train_test_split``.
+    """
+    df = df.copy()
+    df = df.dropna(subset=["track_genre"])
+
+    counts = df["track_genre"].value_counts()
+    keep = counts[counts >= min_samples_per_genre].index
+    df = df[df["track_genre"].isin(keep)].reset_index(drop=True)
+
+    if df.empty:
+        raise ValueError(
+            f"No genres have at least {min_samples_per_genre} samples."
+        )
+
+    if "explicit" in df.columns:
+        df["explicit"] = df["explicit"].fillna(False).astype(int)
+
+    feature_cols = [c for c in AUDIO_FEATURES_FOR_HIT_CLASSIFICATION if c in df.columns]
+    for col in feature_cols:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+        df[col] = df[col].fillna(df[col].median())
+
+    X = df[feature_cols].astype(float)
+    y = df["track_genre"].astype(str)
+    return X, y
+
+
+def split_genre_data(
+    X: pd.DataFrame,
+    y: pd.Series,
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
+    """Stratified train/test split on the genre target."""
+    return train_test_split(
+        X, y, test_size=test_size, random_state=random_state, stratify=y
+    )
+
+
+def train_logistic_genre_classifier(
+    X_train: pd.DataFrame, y_train: pd.Series
+) -> Pipeline:
+    """Fit a multinomial logistic regression with feature scaling."""
+    pipeline = Pipeline(
+        steps=[
+            ("scaler", StandardScaler()),
+            ("classifier", LogisticRegression(**LR_PARAMS)),
+        ]
+    )
+    pipeline.fit(X_train, y_train)
+    return pipeline
+
+
+def train_random_forest_genre_classifier(
+    X_train: pd.DataFrame, y_train: pd.Series
+) -> RandomForestClassifier:
+    """Fit a multi-class random forest classifier."""
+    model = RandomForestClassifier(**RF_PARAMS)
+    model.fit(X_train, y_train)
+    return model
+
+
+def top_k_accuracy(model: Any, X: pd.DataFrame, y: pd.Series, k: int = 3) -> float:
+    """Fraction of samples where the true label is among the top-``k`` probas.
+
+    Falls back to plain ``accuracy_score`` when the model exposes fewer than
+    ``k`` classes.
+    """
+    if not hasattr(model, "predict_proba"):
+        raise TypeError("Model must implement predict_proba for top_k_accuracy.")
+
+    classes = np.asarray(model.classes_)
+    k = min(k, len(classes))
+
+    probabilities = model.predict_proba(X)
+    top_k_idx = np.argsort(probabilities, axis=1)[:, -k:]
+    top_k_labels = classes[top_k_idx]
+
+    y_arr = np.asarray(y)[:, None]
+    matches = (top_k_labels == y_arr).any(axis=1)
+    return float(matches.mean())
+
+
+def evaluate_genre_model(
+    model: Any,
+    X_test: pd.DataFrame,
+    y_test: pd.Series,
+    model_name: str = "Model",
+    top_k: int = 3,
+) -> dict[str, Any]:
+    """Score ``model`` on the held-out set with multi-class metrics."""
+    predictions = model.predict(X_test)
+
+    accuracy = accuracy_score(y_test, predictions)
+    macro = f1_score(y_test, predictions, average="macro", zero_division=0)
+    weighted = f1_score(y_test, predictions, average="weighted", zero_division=0)
+    top_k_score = top_k_accuracy(model, X_test, y_test, k=top_k)
+
+    print(f"{model_name} accuracy: {accuracy:.4f}")
+    print(f"{model_name} macro F1: {macro:.4f}")
+    print(f"{model_name} weighted F1: {weighted:.4f}")
+    print(f"{model_name} top-{top_k} accuracy: {top_k_score:.4f}")
+
+    return {
+        "model": model_name,
+        "accuracy": accuracy,
+        "top_k_accuracy": top_k_score,
+        "macro_f1": macro,
+        "weighted_f1": weighted,
+    }
+
+
+def compare_genre_models(results: list[dict[str, Any]]) -> pd.DataFrame:
+    """Return a tidy comparison frame sorted by macro F1 (best first)."""
+    comparison = pd.DataFrame(results)
+    numeric = comparison.select_dtypes(include=["number"]).columns
+    for col in numeric:
+        comparison[col] = comparison[col].round(4)
+    comparison = comparison.sort_values(by="macro_f1", ascending=False).reset_index(
+        drop=True
+    )
+
+    print("\nGenre Model Comparison:")
+    print(comparison.to_string(index=False))
+    return comparison
+
+
+def confusion_matrix_df(
+    model: Any, X_test: pd.DataFrame, y_test: pd.Series
+) -> pd.DataFrame:
+    """Return the confusion matrix as a DataFrame indexed by class label."""
+    predictions = model.predict(X_test)
+    labels = sorted(set(np.unique(y_test)) | set(np.unique(predictions)))
+    matrix = confusion_matrix(y_test, predictions, labels=labels)
+    return pd.DataFrame(matrix, index=labels, columns=labels)
+
+
+def save_outputs(
+    comparison_df: pd.DataFrame,
+    confusion_df: pd.DataFrame,
+    predictions_df: pd.DataFrame,
+    output_dir: str | Path = "outputs",
+) -> dict[str, str]:
+    """Write the three genre-classifier artifacts to ``output_dir``."""
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    comparison_path = output_path / "genre_model_comparison.csv"
+    confusion_path = output_path / "genre_confusion_matrix.csv"
+    predictions_path = output_path / "genre_predictions.csv"
+
+    comparison_df.to_csv(comparison_path, index=False)
+    confusion_df.to_csv(confusion_path)
+    predictions_df.to_csv(predictions_path, index=False)
+
+    return {
+        "comparison": str(comparison_path),
+        "confusion_matrix": str(confusion_path),
+        "predictions": str(predictions_path),
+    }
+
+
+def run_genre_classifier_pipeline(
+    data_path: str = "data/raw/spotify_data.csv",
+    min_samples_per_genre: int = 50,
+    save_results: bool = True,
+    output_dir: str | Path = "outputs",
+) -> dict[str, Any]:
+    """End-to-end pipeline: load, prep, split, train, evaluate, compare, save."""
+    df = load_data(data_path)
+    validate_data(df)
+
+    X, y = prepare_genre_data(df, min_samples_per_genre=min_samples_per_genre)
+    X_train, X_test, y_train, y_test = split_genre_data(X, y)
+
+    logistic_model = train_logistic_genre_classifier(X_train, y_train)
+    logistic_results = evaluate_genre_model(
+        logistic_model, X_test, y_test, "Logistic Regression"
+    )
+
+    rf_model = train_random_forest_genre_classifier(X_train, y_train)
+    rf_results = evaluate_genre_model(rf_model, X_test, y_test, "Random Forest")
+
+    comparison_df = compare_genre_models([logistic_results, rf_results])
+    confusion_df = confusion_matrix_df(rf_model, X_test, y_test)
+    predictions_df = pd.DataFrame(
+        {
+            "actual_genre": y_test.values,
+            "logistic_prediction": logistic_model.predict(X_test),
+            "random_forest_prediction": rf_model.predict(X_test),
+        }
+    )
+
+    if save_results:
+        save_outputs(comparison_df, confusion_df, predictions_df, output_dir=output_dir)
+
+    return {
+        "logistic_model": logistic_model,
+        "random_forest_model": rf_model,
+        "comparison": comparison_df,
+        "confusion_matrix": confusion_df,
+        "predictions": predictions_df,
+    }
+
+
+def main() -> None:
+    """Run the default genre-classifier pipeline."""
+    run_genre_classifier_pipeline("data/raw/spotify_data.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/unwrapped/hit_shape_predictor.py
+++ b/src/unwrapped/hit_shape_predictor.py
@@ -15,7 +15,7 @@ import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
-from sklearn.model_selection import train_test_split, cross_val_score
+from sklearn.model_selection import RandomizedSearchCV, train_test_split, cross_val_score
 
 from .io import load_data
 
@@ -34,6 +34,20 @@ LR_PARAMS: dict = {
     "max_iter": 1000,
     "random_state": 42,
     "class_weight": "balanced",
+}
+
+DEFAULT_RF_CLF_PARAM_DISTRIBUTIONS: dict = {
+    "n_estimators": [100, 200, 300, 500],
+    "max_depth": [None, 10, 20, 30],
+    "min_samples_split": [2, 5, 10],
+    "max_features": ["sqrt", "log2"],
+}
+
+THRESHOLD_METRIC_FUNCS = {
+    "accuracy": accuracy_score,
+    "precision": lambda y, p: precision_score(y, p, zero_division=0),
+    "recall": lambda y, p: recall_score(y, p, zero_division=0),
+    "f1": lambda y, p: f1_score(y, p, zero_division=0),
 }
 
 REQUIRED_COLUMNS = [
@@ -246,6 +260,129 @@ def train_random_forest(X_train, y_train):
     model = RandomForestClassifier(**RF_PARAMS)
     model.fit(X_train, y_train)
     return model
+
+
+def tune_random_forest_classifier(
+    X_train,
+    y_train,
+    param_distributions=None,
+    cv=5,
+    n_iter=20,
+    scoring="f1",
+    random_state=42,
+):
+    """Tune ``RandomForestClassifier`` hyperparameters with ``RandomizedSearchCV``.
+
+    Returns a dict with ``best_estimator``, ``best_params``, ``best_score``
+    (mean CV score, larger-is-better), and ``cv_results`` (DataFrame ranked
+    best-first).
+    """
+    if param_distributions is None:
+        param_distributions = DEFAULT_RF_CLF_PARAM_DISTRIBUTIONS
+
+    base_model = RandomForestClassifier(
+        random_state=random_state, n_jobs=1, class_weight="balanced"
+    )
+
+    search = RandomizedSearchCV(
+        estimator=base_model,
+        param_distributions=param_distributions,
+        n_iter=n_iter,
+        cv=cv,
+        scoring=scoring,
+        random_state=random_state,
+        n_jobs=1,
+        refit=True,
+    )
+    search.fit(X_train, y_train)
+
+    cv_results = pd.DataFrame(
+        {
+            "params": search.cv_results_["params"],
+            "mean_test_score": search.cv_results_["mean_test_score"],
+            "std_test_score": search.cv_results_["std_test_score"],
+            "rank_test_score": search.cv_results_["rank_test_score"],
+        }
+    ).sort_values("rank_test_score").reset_index(drop=True)
+
+    return {
+        "best_estimator": search.best_estimator_,
+        "best_params": search.best_params_,
+        "best_score": float(search.best_score_),
+        "cv_results": cv_results,
+    }
+
+
+def predict_with_threshold(model, X, threshold):
+    """Return 0/1 predictions using a custom probability cutoff.
+
+    Uses ``model.predict_proba(X)[:, 1] >= threshold``. The 1-class column is
+    selected so the threshold is interpretable as P(hit).
+    """
+    if not hasattr(model, "predict_proba"):
+        raise TypeError("Model must implement predict_proba for threshold tuning.")
+
+    probabilities = model.predict_proba(X)[:, 1]
+    return (probabilities >= threshold).astype(int)
+
+
+def compute_threshold_curve(model, X_val, y_val, thresholds=None):
+    """Sweep decision thresholds and report classification metrics at each.
+
+    Returns a DataFrame with columns ``threshold, accuracy, precision,
+    recall, f1`` ordered by ascending threshold. When ``thresholds`` is
+    ``None``, sweeps ``np.linspace(0.05, 0.95, 91)``.
+    """
+    if thresholds is None:
+        thresholds = np.linspace(0.05, 0.95, 91)
+    thresholds = np.asarray(thresholds, dtype=float)
+
+    probabilities = model.predict_proba(X_val)[:, 1]
+    y_val_arr = np.asarray(y_val)
+
+    rows = []
+    for t in thresholds:
+        preds = (probabilities >= t).astype(int)
+        rows.append(
+            {
+                "threshold": float(t),
+                "accuracy": accuracy_score(y_val_arr, preds),
+                "precision": precision_score(y_val_arr, preds, zero_division=0),
+                "recall": recall_score(y_val_arr, preds, zero_division=0),
+                "f1": f1_score(y_val_arr, preds, zero_division=0),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def find_optimal_threshold(model, X_val, y_val, metric="f1", thresholds=None):
+    """Pick the probability threshold that maximizes ``metric``.
+
+    Parameters
+    ----------
+    metric : {"f1", "accuracy", "precision", "recall"}, default "f1"
+        Column from :func:`compute_threshold_curve` to optimize.
+
+    Returns
+    -------
+    dict
+        ``best_threshold``, ``best_score``, ``metric``, and the full ``curve``.
+    """
+    if metric not in THRESHOLD_METRIC_FUNCS:
+        raise ValueError(
+            f"Unknown metric '{metric}'. Choose from {sorted(THRESHOLD_METRIC_FUNCS)}."
+        )
+
+    curve = compute_threshold_curve(model, X_val, y_val, thresholds=thresholds)
+    best_row = curve.iloc[curve[metric].idxmax()]
+
+    return {
+        "best_threshold": float(best_row["threshold"]),
+        "best_score": float(best_row[metric]),
+        "metric": metric,
+        "curve": curve,
+    }
 
 
 def evaluate_model(model, X_test, y_test, model_name="Model"):

--- a/src/unwrapped/io.py
+++ b/src/unwrapped/io.py
@@ -1,6 +1,15 @@
-"""Utilities for loading the Spotify dataset."""
+"""Utilities for loading the Spotify dataset and persisting trained models."""
 
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import joblib
 import pandas as pd
+import sklearn
 
 DEFAULT_DATA_PATH = "data/raw/spotify_data.csv"
 
@@ -46,4 +55,73 @@ def load_json(path: str) -> pd.DataFrame:
     """
     df = pd.read_json(path)
     return _drop_index_column(df)
+
+
+def _meta_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".meta.json")
+
+
+def save_model(
+    model: Any,
+    path: str | Path,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, str]:
+    """Persist a fitted estimator to disk along with a JSON metadata sidecar.
+
+    The estimator is serialized with ``joblib.dump`` and a sibling
+    ``<path>.meta.json`` file records the model class, sklearn version, the
+    training timestamp, and any caller-supplied keys (e.g. ``feature_names``,
+    ``target``).
+
+    Parameters
+    ----------
+    model : Any
+        A fitted scikit-learn estimator (or any joblib-serializable object).
+    path : str | Path
+        Destination file path. Parent directories are created when missing.
+    metadata : dict, optional
+        Extra keys merged into the sidecar JSON.
+
+    Returns
+    -------
+    dict
+        Mapping with ``"model"`` and ``"metadata"`` keys pointing to the
+        written file paths.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    joblib.dump(model, path)
+
+    sidecar: dict[str, Any] = {
+        "model_class": type(model).__name__,
+        "sklearn_version": sklearn.__version__,
+        "trained_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    if metadata:
+        sidecar.update(metadata)
+
+    meta_path = _meta_path(path)
+    with open(meta_path, "w", encoding="utf-8") as fh:
+        json.dump(sidecar, fh, indent=2, default=str)
+
+    return {"model": str(path), "metadata": str(meta_path)}
+
+
+def load_model(path: str | Path) -> tuple[Any, dict[str, Any] | None]:
+    """Load a model previously written by :func:`save_model`.
+
+    Returns ``(model, metadata)``. ``metadata`` is ``None`` when the sidecar
+    file is absent, so this helper still works on bare joblib dumps.
+    """
+    path = Path(path)
+    model = joblib.load(path)
+
+    meta_path = _meta_path(path)
+    metadata: dict[str, Any] | None = None
+    if meta_path.exists():
+        with open(meta_path, "r", encoding="utf-8") as fh:
+            metadata = json.load(fh)
+
+    return model, metadata
 

--- a/src/unwrapped/popularity.py
+++ b/src/unwrapped/popularity.py
@@ -16,7 +16,7 @@ import argparse
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
-from sklearn.model_selection import cross_val_score, train_test_split
+from sklearn.model_selection import RandomizedSearchCV, cross_val_score, train_test_split
 
 from .io import load_data
 
@@ -31,6 +31,13 @@ RF_PARAMS: dict = {
     "min_samples_leaf": 1,
     "random_state": 42,
     "n_jobs": 1,
+}
+
+DEFAULT_RF_PARAM_DISTRIBUTIONS: dict = {
+    "n_estimators": [100, 200, 300, 500],
+    "max_depth": [None, 10, 20, 30],
+    "min_samples_split": [2, 5, 10],
+    "max_features": ["sqrt", "log2"],
 }
 
 REQUIRED_COLUMNS: list[str] = [
@@ -176,6 +183,74 @@ def train_random_forest(
     model = RandomForestRegressor(**RF_PARAMS)
     model.fit(X_train, y_train)
     return model
+
+
+def tune_random_forest(
+    X_train: pd.DataFrame,
+    y_train: pd.Series,
+    param_distributions: dict | None = None,
+    cv: int = 5,
+    n_iter: int = 20,
+    scoring: str = "neg_root_mean_squared_error",
+    random_state: int = 42,
+) -> dict[str, Any]:
+    """Tune a ``RandomForestRegressor`` with ``RandomizedSearchCV``.
+
+    Parameters
+    ----------
+    X_train, y_train :
+        Training features and target.
+    param_distributions : dict, optional
+        Mapping of hyperparameter names to value lists. Defaults to
+        :data:`DEFAULT_RF_PARAM_DISTRIBUTIONS`.
+    cv : int, default 5
+        Number of cross-validation folds.
+    n_iter : int, default 20
+        Candidates sampled from ``param_distributions``.
+    scoring : str, default ``"neg_root_mean_squared_error"``
+        Scoring metric forwarded to ``RandomizedSearchCV``.
+    random_state : int, default 42
+        Seed used both for the base estimator and the parameter sampler.
+
+    Returns
+    -------
+    dict
+        ``best_estimator`` (refit on the full training set), ``best_params``,
+        ``best_score`` (mean CV score, larger-is-better), and ``cv_results``
+        (DataFrame with one row per sampled candidate).
+    """
+    if param_distributions is None:
+        param_distributions = DEFAULT_RF_PARAM_DISTRIBUTIONS
+
+    base_model = RandomForestRegressor(random_state=random_state, n_jobs=1)
+
+    search = RandomizedSearchCV(
+        estimator=base_model,
+        param_distributions=param_distributions,
+        n_iter=n_iter,
+        cv=cv,
+        scoring=scoring,
+        random_state=random_state,
+        n_jobs=1,
+        refit=True,
+    )
+    search.fit(X_train, y_train)
+
+    cv_results = pd.DataFrame(
+        {
+            "params": search.cv_results_["params"],
+            "mean_test_score": search.cv_results_["mean_test_score"],
+            "std_test_score": search.cv_results_["std_test_score"],
+            "rank_test_score": search.cv_results_["rank_test_score"],
+        }
+    ).sort_values("rank_test_score").reset_index(drop=True)
+
+    return {
+        "best_estimator": search.best_estimator_,
+        "best_params": search.best_params_,
+        "best_score": float(search.best_score_),
+        "cv_results": cv_results,
+    }
 
 
 def evaluate_model(

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from unwrapped.clustering import (
+    cluster_centroids,
+    cluster_songs,
+    cluster_summary,
+    find_optimal_k,
+    prepare_clustering_data,
+    run_clustering_pipeline,
+    save_outputs,
+)
+
+
+def make_row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "track_id": "t",
+        "artists": "Artist",
+        "album_name": "Album",
+        "track_name": "Song",
+        "track_genre": "pop",
+        "popularity": 50,
+        "duration_ms": 200000,
+        "explicit": 0,
+        "danceability": 0.6,
+        "energy": 0.7,
+        "key": 5,
+        "loudness": -5.0,
+        "mode": 1,
+        "speechiness": 0.05,
+        "acousticness": 0.2,
+        "instrumentalness": 0.0,
+        "liveness": 0.1,
+        "valence": 0.5,
+        "tempo": 120.0,
+        "time_signature": 4,
+    }
+    row.update(overrides)
+    return row
+
+
+def make_df() -> pd.DataFrame:
+    """Three well-separated clusters of 8 rows each."""
+    rows: list[dict[str, Any]] = []
+    rng = np.random.default_rng(42)
+
+    centers = [
+        {"danceability": 0.85, "energy": 0.85, "valence": 0.8, "acousticness": 0.05,
+         "tempo": 130, "popularity": 80, "track_genre": "pop"},
+        {"danceability": 0.4, "energy": 0.85, "valence": 0.4, "acousticness": 0.05,
+         "tempo": 145, "popularity": 50, "track_genre": "rock"},
+        {"danceability": 0.3, "energy": 0.2, "valence": 0.5, "acousticness": 0.85,
+         "tempo": 90, "popularity": 35, "track_genre": "acoustic"},
+    ]
+    for cluster_idx, c in enumerate(centers):
+        for i in range(8):
+            jitter = rng.normal(0, 0.01)
+            rows.append(
+                make_row(
+                    track_id=f"c{cluster_idx}-{i}",
+                    track_genre=c["track_genre"],
+                    popularity=c["popularity"],
+                    danceability=c["danceability"] + jitter,
+                    energy=c["energy"] + jitter,
+                    valence=c["valence"] + jitter,
+                    acousticness=c["acousticness"] + jitter,
+                    tempo=c["tempo"] + rng.normal(0, 0.5),
+                )
+            )
+    return pd.DataFrame(rows)
+
+
+def test_prepare_clustering_data_returns_zero_mean_unit_variance():
+    df = make_df()
+    X_scaled, scaler, feature_names, kept_index = prepare_clustering_data(df)
+
+    assert X_scaled.shape == (len(df), len(feature_names))
+    np.testing.assert_allclose(X_scaled.mean(axis=0), 0.0, atol=1e-9)
+    # Each scaled column should be either ~0 (constant input) or ~1 (varying);
+    # sklearn's StandardScaler leaves zero-variance columns at 0.
+    scaled_std = X_scaled.std(axis=0)
+    near_zero_or_one = np.isclose(scaled_std, 0.0, atol=1e-9) | np.isclose(
+        scaled_std, 1.0, atol=1e-9
+    )
+    assert near_zero_or_one.all()
+    # At least some columns must be nontrivially scaled.
+    assert np.isclose(scaled_std, 1.0, atol=1e-9).any()
+    assert list(kept_index) == list(df.index)
+
+
+def test_prepare_clustering_data_drops_rows_missing_features():
+    df = make_df()
+    df.loc[0, "danceability"] = np.nan
+
+    X_scaled, _, _, kept_index = prepare_clustering_data(df)
+
+    assert len(X_scaled) == len(df) - 1
+    assert 0 not in kept_index
+
+
+def test_prepare_clustering_data_raises_on_missing_columns():
+    df = make_df().drop(columns=["energy"])
+    with pytest.raises(ValueError, match="Missing required columns"):
+        prepare_clustering_data(df)
+
+
+def test_prepare_clustering_data_accepts_custom_feature_list():
+    df = make_df()
+    X_scaled, _, feature_names, _ = prepare_clustering_data(
+        df, features=["danceability", "energy"]
+    )
+
+    assert feature_names == ["danceability", "energy"]
+    assert X_scaled.shape[1] == 2
+
+
+def test_find_optimal_k_returns_required_columns():
+    df = make_df()
+    X_scaled, _, _, _ = prepare_clustering_data(df)
+
+    result = find_optimal_k(X_scaled, k_range=range(2, 5))
+
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == ["k", "inertia", "silhouette"]
+    assert list(result["k"]) == [2, 3, 4]
+
+
+def test_find_optimal_k_inertia_is_non_increasing():
+    df = make_df()
+    X_scaled, _, _, _ = prepare_clustering_data(df)
+
+    result = find_optimal_k(X_scaled, k_range=range(2, 6))
+
+    inertias = result["inertia"].to_list()
+    assert all(a >= b - 1e-9 for a, b in zip(inertias, inertias[1:]))
+
+
+def test_cluster_songs_adds_cluster_column():
+    df = make_df()
+    df_clustered, model, scaler = cluster_songs(df, n_clusters=3)
+
+    assert "cluster" in df_clustered.columns
+    assert len(df_clustered) == len(df)
+    assigned = df_clustered.loc[df_clustered["cluster"] >= 0, "cluster"].unique()
+    assert set(assigned) == {0, 1, 2}
+    assert hasattr(model, "cluster_centers_")
+
+
+def test_cluster_songs_marks_rows_with_missing_features_as_minus_one():
+    df = make_df()
+    df.loc[0, "danceability"] = np.nan
+
+    df_clustered, _, _ = cluster_songs(df, n_clusters=3)
+
+    assert df_clustered.loc[0, "cluster"] == -1
+
+
+def test_cluster_centroids_shape_and_range():
+    df = make_df()
+    df_clustered, model, scaler = cluster_songs(df, n_clusters=3)
+    _, _, feature_names, _ = prepare_clustering_data(df)
+
+    centroids = cluster_centroids(model, scaler, feature_names)
+
+    assert centroids.shape == (3, len(feature_names))
+    assert list(centroids.columns) == feature_names
+    for feat in feature_names:
+        feat_min, feat_max = df[feat].min(), df[feat].max()
+        spread = feat_max - feat_min
+        # Centroids should sit within the data range (allow a tiny float margin).
+        assert centroids[feat].min() >= feat_min - 1e-6 * max(1.0, spread)
+        assert centroids[feat].max() <= feat_max + 1e-6 * max(1.0, spread)
+
+
+def test_cluster_summary_one_row_per_cluster():
+    df = make_df()
+    df_clustered, _, _ = cluster_songs(df, n_clusters=3)
+
+    summary = cluster_summary(df_clustered)
+
+    assert len(summary) == 3
+    assert {"cluster", "size", "mean_popularity", "top_genre"} <= set(summary.columns)
+    assert summary["size"].sum() == len(df)
+    assert summary["cluster"].is_monotonic_increasing
+
+
+def test_cluster_summary_has_one_mean_column_per_audio_feature():
+    df = make_df()
+    df_clustered, _, _ = cluster_songs(df, n_clusters=2)
+
+    summary = cluster_summary(df_clustered)
+
+    for feat in ["danceability", "energy", "valence", "acousticness", "tempo"]:
+        assert f"mean_{feat}" in summary.columns
+
+
+def test_save_outputs_writes_expected_files(tmp_path: Path):
+    assignments = pd.DataFrame({"track_id": ["a"], "cluster": [0]})
+    centroids = pd.DataFrame([[0.5, 0.7]], columns=["danceability", "energy"])
+    summary = pd.DataFrame({"cluster": [0], "size": [1]})
+    k_search = pd.DataFrame({"k": [2, 3], "inertia": [10.0, 8.0], "silhouette": [0.5, 0.6]})
+
+    paths = save_outputs(
+        assignments, centroids, summary, k_search, output_dir=tmp_path / "out"
+    )
+
+    assert {"assignments", "centroids", "summary", "k_search"} <= paths.keys()
+    assert (tmp_path / "out" / "cluster_assignments.csv").exists()
+    assert (tmp_path / "out" / "cluster_centroids.csv").exists()
+    assert (tmp_path / "out" / "cluster_summary.csv").exists()
+    assert (tmp_path / "out" / "cluster_k_search.csv").exists()
+
+
+def test_save_outputs_omits_k_search_when_none(tmp_path: Path):
+    assignments = pd.DataFrame({"track_id": ["a"], "cluster": [0]})
+    centroids = pd.DataFrame([[0.5]], columns=["danceability"])
+    summary = pd.DataFrame({"cluster": [0], "size": [1]})
+
+    paths = save_outputs(assignments, centroids, summary, None, output_dir=tmp_path / "out")
+
+    assert "k_search" not in paths
+    assert not (tmp_path / "out" / "cluster_k_search.csv").exists()
+
+
+def test_run_clustering_pipeline_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    df = make_df()
+    monkeypatch.setattr("unwrapped.clustering.load_data", lambda _: df)
+
+    output_dir = tmp_path / "pipeline"
+    result = run_clustering_pipeline(
+        data_path="fake.csv",
+        n_clusters=3,
+        k_search_range=range(2, 5),
+        save_results=True,
+        output_dir=output_dir,
+    )
+
+    assert {"model", "scaler", "assignments", "centroids", "summary", "k_search"} <= result.keys()
+    assert len(result["centroids"]) == 3
+    assert len(result["summary"]) == 3
+    assert (output_dir / "cluster_assignments.csv").exists()
+    assert (output_dir / "cluster_summary.csv").exists()
+    assert (output_dir / "cluster_k_search.csv").exists()

--- a/tests/test_genre_classifier.py
+++ b/tests/test_genre_classifier.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from unwrapped.genre_classifier import (
+    compare_genre_models,
+    confusion_matrix_df,
+    evaluate_genre_model,
+    prepare_genre_data,
+    run_genre_classifier_pipeline,
+    save_outputs,
+    split_genre_data,
+    top_k_accuracy,
+    train_logistic_genre_classifier,
+    train_random_forest_genre_classifier,
+    validate_data,
+)
+
+
+def make_row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "track_id": "t",
+        "artists": "Artist",
+        "album_name": "Album",
+        "track_name": "Song",
+        "track_genre": "pop",
+        "popularity": 50,
+        "duration_ms": 200000,
+        "explicit": 0,
+        "danceability": 0.6,
+        "energy": 0.7,
+        "key": 5,
+        "loudness": -5.0,
+        "mode": 1,
+        "speechiness": 0.05,
+        "acousticness": 0.2,
+        "instrumentalness": 0.0,
+        "liveness": 0.1,
+        "valence": 0.5,
+        "tempo": 120.0,
+        "time_signature": 4,
+    }
+    row.update(overrides)
+    return row
+
+
+def make_df() -> pd.DataFrame:
+    """Three genres with 8 rows each — enough for a 0.25 stratified split."""
+    rows: list[dict[str, Any]] = []
+    rng = np.random.default_rng(0)
+    for i in range(8):
+        rows.append(
+            make_row(
+                track_id=f"pop-{i}",
+                track_genre="pop",
+                danceability=0.7 + rng.normal(0, 0.02),
+                energy=0.8 + rng.normal(0, 0.02),
+                valence=0.7 + rng.normal(0, 0.02),
+                acousticness=0.1 + rng.normal(0, 0.02),
+                tempo=120 + rng.normal(0, 1),
+            )
+        )
+    for i in range(8):
+        rows.append(
+            make_row(
+                track_id=f"rock-{i}",
+                track_genre="rock",
+                danceability=0.4 + rng.normal(0, 0.02),
+                energy=0.85 + rng.normal(0, 0.02),
+                valence=0.4 + rng.normal(0, 0.02),
+                acousticness=0.05 + rng.normal(0, 0.02),
+                tempo=140 + rng.normal(0, 1),
+            )
+        )
+    for i in range(8):
+        rows.append(
+            make_row(
+                track_id=f"acoustic-{i}",
+                track_genre="acoustic",
+                danceability=0.3 + rng.normal(0, 0.02),
+                energy=0.2 + rng.normal(0, 0.02),
+                valence=0.5 + rng.normal(0, 0.02),
+                acousticness=0.85 + rng.normal(0, 0.02),
+                tempo=90 + rng.normal(0, 1),
+            )
+        )
+    return pd.DataFrame(rows)
+
+
+def test_validate_data_passes_for_valid_dataframe():
+    validate_data(make_df())
+
+
+def test_validate_data_raises_on_empty_dataframe():
+    with pytest.raises(ValueError, match="empty"):
+        validate_data(pd.DataFrame())
+
+
+def test_validate_data_raises_when_track_genre_missing():
+    df = make_df().drop(columns=["track_genre"])
+    with pytest.raises(ValueError, match="track_genre"):
+        validate_data(df)
+
+
+def test_prepare_genre_data_filters_rare_genres():
+    df = make_df()
+    df = pd.concat([df, pd.DataFrame([make_row(track_genre="metal")])], ignore_index=True)
+
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+
+    assert "metal" not in set(y)
+    assert set(y) == {"pop", "rock", "acoustic"}
+    assert len(X) == len(y) == 24
+
+
+def test_prepare_genre_data_raises_when_all_genres_filtered_out():
+    df = make_df()
+    with pytest.raises(ValueError, match="No genres"):
+        prepare_genre_data(df, min_samples_per_genre=999)
+
+
+def test_prepare_genre_data_returns_audio_feature_columns():
+    df = make_df()
+    X, _ = prepare_genre_data(df, min_samples_per_genre=5)
+
+    expected = {
+        "danceability", "energy", "loudness", "speechiness", "acousticness",
+        "instrumentalness", "liveness", "valence", "tempo", "duration_ms",
+        "explicit", "key", "mode", "time_signature",
+    }
+    assert expected <= set(X.columns)
+    assert "track_genre" not in X.columns
+
+
+def test_split_genre_data_preserves_class_set():
+    df = make_df()
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+    X_train, X_test, y_train, y_test = split_genre_data(X, y, test_size=0.25)
+
+    assert len(X_train) > 0 and len(X_test) > 0
+    assert set(y_train) == set(y_test) == set(y)
+
+
+def test_train_logistic_returns_pipeline_with_predict_proba():
+    df = make_df()
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+    X_train, _, y_train, _ = split_genre_data(X, y, test_size=0.25)
+
+    model = train_logistic_genre_classifier(X_train, y_train)
+    assert hasattr(model, "predict")
+    assert hasattr(model, "predict_proba")
+
+
+def test_train_random_forest_has_feature_importances():
+    df = make_df()
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+    X_train, _, y_train, _ = split_genre_data(X, y, test_size=0.25)
+
+    model = train_random_forest_genre_classifier(X_train, y_train)
+    assert hasattr(model, "feature_importances_")
+    assert len(model.feature_importances_) == X_train.shape[1]
+
+
+def test_top_k_accuracy_within_unit_interval_and_at_least_accuracy():
+    df = make_df()
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+    X_train, X_test, y_train, y_test = split_genre_data(X, y, test_size=0.25)
+    model = train_random_forest_genre_classifier(X_train, y_train)
+
+    top1 = top_k_accuracy(model, X_test, y_test, k=1)
+    top3 = top_k_accuracy(model, X_test, y_test, k=3)
+
+    assert 0.0 <= top1 <= 1.0
+    assert 0.0 <= top3 <= 1.0
+    assert top3 >= top1 - 1e-9
+
+
+def test_top_k_accuracy_requires_predict_proba():
+    class NoProba:
+        classes_ = np.array(["a"])
+
+        def predict(self, X):
+            return ["a"] * len(X)
+
+    with pytest.raises(TypeError, match="predict_proba"):
+        top_k_accuracy(NoProba(), pd.DataFrame({"x": [1]}), pd.Series(["a"]))
+
+
+def test_evaluate_genre_model_returns_expected_keys():
+    df = make_df()
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+    X_train, X_test, y_train, y_test = split_genre_data(X, y, test_size=0.25)
+    model = train_random_forest_genre_classifier(X_train, y_train)
+
+    result = evaluate_genre_model(model, X_test, y_test, "RF", top_k=2)
+
+    assert set(result.keys()) == {
+        "model", "accuracy", "top_k_accuracy", "macro_f1", "weighted_f1"
+    }
+    assert result["model"] == "RF"
+
+
+def test_compare_genre_models_sorts_by_macro_f1_desc():
+    results = [
+        {"model": "A", "accuracy": 0.8, "top_k_accuracy": 0.95, "macro_f1": 0.6, "weighted_f1": 0.7},
+        {"model": "B", "accuracy": 0.7, "top_k_accuracy": 0.90, "macro_f1": 0.8, "weighted_f1": 0.75},
+    ]
+
+    comparison = compare_genre_models(results)
+
+    assert comparison.iloc[0]["model"] == "B"
+    assert comparison["macro_f1"].is_monotonic_decreasing
+
+
+def test_confusion_matrix_df_is_square_with_class_labels():
+    df = make_df()
+    X, y = prepare_genre_data(df, min_samples_per_genre=5)
+    X_train, X_test, y_train, y_test = split_genre_data(X, y, test_size=0.25)
+    model = train_random_forest_genre_classifier(X_train, y_train)
+
+    cm = confusion_matrix_df(model, X_test, y_test)
+
+    assert cm.shape[0] == cm.shape[1]
+    assert set(cm.index) == set(cm.columns)
+    assert set(y_test).issubset(set(cm.index))
+
+
+def test_save_outputs_writes_three_csvs(tmp_path: Path):
+    comparison = pd.DataFrame({"model": ["A"], "macro_f1": [0.8]})
+    confusion = pd.DataFrame([[1, 0], [0, 1]], index=["a", "b"], columns=["a", "b"])
+    predictions = pd.DataFrame({"actual_genre": ["a"], "random_forest_prediction": ["a"]})
+
+    paths = save_outputs(comparison, confusion, predictions, output_dir=tmp_path / "out")
+
+    assert set(paths.keys()) == {"comparison", "confusion_matrix", "predictions"}
+    assert (tmp_path / "out" / "genre_model_comparison.csv").exists()
+    assert (tmp_path / "out" / "genre_confusion_matrix.csv").exists()
+    assert (tmp_path / "out" / "genre_predictions.csv").exists()
+
+
+def test_run_genre_classifier_pipeline_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    big_df = pd.concat([make_df()] * 3, ignore_index=True)
+    big_df["track_id"] = [str(i) for i in range(len(big_df))]
+
+    monkeypatch.setattr("unwrapped.genre_classifier.load_data", lambda _: big_df)
+
+    output_dir = tmp_path / "pipeline"
+    result = run_genre_classifier_pipeline(
+        data_path="fake.csv",
+        min_samples_per_genre=5,
+        save_results=True,
+        output_dir=output_dir,
+    )
+
+    assert {"logistic_model", "random_forest_model", "comparison", "confusion_matrix",
+            "predictions"} <= result.keys()
+    assert not result["comparison"].empty
+    assert (output_dir / "genre_model_comparison.csv").exists()

--- a/tests/test_hit_shape_predictor.py
+++ b/tests/test_hit_shape_predictor.py
@@ -1,7 +1,9 @@
+import numpy as np
 import pandas as pd
 import pytest
 
 from unwrapped.hit_shape_predictor import (
+    DEFAULT_RF_CLF_PARAM_DISTRIBUTIONS,
     validate_data,
     handle_missing_values,
     preprocess_data,
@@ -13,6 +15,10 @@ from unwrapped.hit_shape_predictor import (
     split_data,
     train_logistic_model,
     train_random_forest,
+    tune_random_forest_classifier,
+    compute_threshold_curve,
+    find_optimal_threshold,
+    predict_with_threshold,
     evaluate_model,
     compare_models,
     build_predictions_df,
@@ -251,6 +257,127 @@ def test_compare_models_sorts_highest_f1_first():
     comparison = compare_models(results)
 
     assert comparison.iloc[0]["model"] == "B"
+
+
+def _make_trained_classifier(test_size=0.5):
+    """Train a simple RF on the synthetic dataset for threshold tests."""
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, X_test, y_train, y_test = split_data(
+        model_df, test_size=test_size, random_state=42
+    )
+    model = train_random_forest(X_train, y_train)
+    return model, X_test, y_test
+
+
+def test_tune_random_forest_classifier_returns_expected_keys():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, _, y_train, _ = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    result = tune_random_forest_classifier(X_train, y_train, n_iter=2, cv=2)
+
+    assert set(result.keys()) == {"best_estimator", "best_params", "best_score", "cv_results"}
+    assert hasattr(result["best_estimator"], "feature_importances_")
+    assert hasattr(result["best_estimator"], "predict_proba")
+
+
+def test_tune_random_forest_classifier_cv_results_ranked():
+    df = prepare_df()
+    similarity_df = compute_similarity_features(df)
+    model_df = build_modeling_dataframe(similarity_df)
+    X_train, _, y_train, _ = split_data(
+        model_df, test_size=0.25, random_state=42
+    )
+
+    result = tune_random_forest_classifier(X_train, y_train, n_iter=3, cv=2)
+    cv_results = result["cv_results"]
+
+    assert isinstance(cv_results, pd.DataFrame)
+    assert len(cv_results) == 3
+    assert cv_results.iloc[0]["rank_test_score"] == 1
+
+
+def test_default_rf_clf_param_distributions_contains_expected_keys():
+    assert {"n_estimators", "max_depth", "min_samples_split", "max_features"} <= set(
+        DEFAULT_RF_CLF_PARAM_DISTRIBUTIONS.keys()
+    )
+
+
+def test_compute_threshold_curve_columns_and_ordering():
+    model, X_test, y_test = _make_trained_classifier()
+
+    curve = compute_threshold_curve(model, X_test, y_test)
+
+    assert {"threshold", "accuracy", "precision", "recall", "f1"} <= set(curve.columns)
+    assert curve["threshold"].is_monotonic_increasing
+    assert (curve[["accuracy", "precision", "recall", "f1"]] >= 0).all().all()
+    assert (curve[["accuracy", "precision", "recall", "f1"]] <= 1).all().all()
+
+
+def test_compute_threshold_curve_respects_custom_thresholds():
+    model, X_test, y_test = _make_trained_classifier()
+    custom = [0.1, 0.5, 0.9]
+
+    curve = compute_threshold_curve(model, X_test, y_test, thresholds=custom)
+
+    assert list(curve["threshold"]) == custom
+
+
+def test_find_optimal_threshold_returns_threshold_in_range():
+    model, X_test, y_test = _make_trained_classifier()
+
+    result = find_optimal_threshold(model, X_test, y_test, metric="f1")
+
+    assert {"best_threshold", "best_score", "metric", "curve"} <= set(result.keys())
+    assert 0.0 <= result["best_threshold"] <= 1.0
+    assert result["metric"] == "f1"
+    assert result["best_score"] >= result["curve"]["f1"].min()
+
+
+def test_find_optimal_threshold_beats_or_matches_default():
+    model, X_test, y_test = _make_trained_classifier()
+
+    result = find_optimal_threshold(model, X_test, y_test, metric="f1")
+
+    default_preds = (model.predict_proba(X_test)[:, 1] >= 0.5).astype(int)
+    from sklearn.metrics import f1_score as _f1
+
+    default_f1 = _f1(y_test, default_preds, zero_division=0)
+    assert result["best_score"] >= default_f1 - 1e-9
+
+
+def test_find_optimal_threshold_rejects_unknown_metric():
+    model, X_test, y_test = _make_trained_classifier()
+
+    with pytest.raises(ValueError, match="Unknown metric"):
+        find_optimal_threshold(model, X_test, y_test, metric="auroc")
+
+
+def test_predict_with_threshold_extreme_values():
+    model, X_test, _ = _make_trained_classifier()
+
+    all_zero = predict_with_threshold(model, X_test, threshold=1.01)
+    all_one = predict_with_threshold(model, X_test, threshold=0.0)
+
+    assert isinstance(all_zero, np.ndarray)
+    assert all_zero.dtype.kind == "i"
+    assert len(all_zero) == len(X_test)
+    assert all_zero.sum() == 0
+    assert all_one.sum() == len(X_test)
+
+
+def test_predict_with_threshold_requires_predict_proba():
+    class NoProba:
+        def predict(self, X):
+            return [0] * len(X)
+
+    with pytest.raises(TypeError, match="predict_proba"):
+        predict_with_threshold(NoProba(), pd.DataFrame({"a": [1, 2]}), threshold=0.5)
 
 
 def test_build_predictions_df_has_expected_columns():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import pytest
+from sklearn.linear_model import LogisticRegression
 
 from unwrapped.clean import run_cleaning
-from unwrapped.io import load_data
+from unwrapped.io import load_data, load_model, save_model
 from unwrapped.validation import run_validation
 
 
@@ -219,3 +223,80 @@ def test_run_validation_raises_when_loaded_data_is_invalid(
 
     with pytest.raises(ValueError, match="Missing columns"):
         run_validation("fake/path.csv")
+
+
+def _toy_classifier() -> LogisticRegression:
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(40, 3))
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    model = LogisticRegression()
+    model.fit(X, y)
+    return model
+
+
+def test_save_and_load_model_round_trip_predictions(tmp_path: Path) -> None:
+    """A round-trip through save_model/load_model must preserve predictions."""
+
+    model = _toy_classifier()
+    rng = np.random.default_rng(1)
+    X_test = rng.normal(size=(10, 3))
+    expected = model.predict(X_test)
+
+    path = tmp_path / "models" / "clf.joblib"
+    paths = save_model(model, path, metadata={"feature_names": ["a", "b", "c"]})
+
+    assert Path(paths["model"]).exists()
+    assert Path(paths["metadata"]).exists()
+
+    loaded_model, metadata = load_model(path)
+    np.testing.assert_array_equal(loaded_model.predict(X_test), expected)
+    assert metadata is not None
+    assert metadata["feature_names"] == ["a", "b", "c"]
+    assert metadata["model_class"] == "LogisticRegression"
+    assert "sklearn_version" in metadata
+    assert "trained_at_utc" in metadata
+
+
+def test_save_model_writes_sidecar_with_caller_metadata(tmp_path: Path) -> None:
+    """Caller-supplied metadata should be merged into the sidecar JSON."""
+
+    model = _toy_classifier()
+    path = tmp_path / "clf.joblib"
+
+    save_model(model, path, metadata={"target": "is_hit", "feature_names": ["x"]})
+
+    with open(path.with_suffix(path.suffix + ".meta.json"), "r", encoding="utf-8") as fh:
+        sidecar = json.load(fh)
+
+    assert sidecar["target"] == "is_hit"
+    assert sidecar["feature_names"] == ["x"]
+    assert sidecar["model_class"] == "LogisticRegression"
+
+
+def test_load_model_returns_none_metadata_when_sidecar_missing(tmp_path: Path) -> None:
+    """Loading a bare joblib dump (no sidecar) should still succeed."""
+
+    import joblib
+
+    model = _toy_classifier()
+    path = tmp_path / "bare.joblib"
+    joblib.dump(model, path)
+
+    loaded, metadata = load_model(path)
+
+    assert metadata is None
+    rng = np.random.default_rng(2)
+    X_test = rng.normal(size=(5, 3))
+    np.testing.assert_array_equal(loaded.predict(X_test), model.predict(X_test))
+
+
+def test_save_model_creates_parent_directories(tmp_path: Path) -> None:
+    """Nested target directories should be created if missing."""
+
+    model = _toy_classifier()
+    path = tmp_path / "nested" / "deep" / "clf.joblib"
+
+    save_model(model, path)
+
+    assert path.exists()
+    assert path.with_suffix(path.suffix + ".meta.json").exists()

--- a/tests/test_popularity.py
+++ b/tests/test_popularity.py
@@ -7,6 +7,7 @@ import pytest
 from sklearn.linear_model import LinearRegression
 
 from unwrapped.popularity import (
+    DEFAULT_RF_PARAM_DISTRIBUTIONS,
     compare_models,
     cross_validate_model,
     evaluate_model,
@@ -18,6 +19,7 @@ from unwrapped.popularity import (
     split_data,
     train_linear_model,
     train_random_forest,
+    tune_random_forest,
     validate_data,
 )
 
@@ -364,6 +366,58 @@ def test_main_exits_cleanly_when_data_file_missing(
         main()
  
     assert exc_info.value.code == 1
+
+# Hyperparameter tuning should return a fitted RF and a cv_results DataFrame.
+def test_tune_random_forest_returns_expected_keys(sample_df):
+    big_df = pd.concat([sample_df] * 4, ignore_index=True)
+    big_df["track_id"] = [str(i) for i in range(len(big_df))]
+    processed = preprocess_data(big_df)
+    X_train, _, y_train, _ = split_data(processed, test_size=0.25)
+
+    result = tune_random_forest(X_train, y_train, n_iter=2, cv=2)
+
+    assert set(result.keys()) == {"best_estimator", "best_params", "best_score", "cv_results"}
+    assert hasattr(result["best_estimator"], "feature_importances_")
+    assert isinstance(result["best_params"], dict)
+    assert isinstance(result["best_score"], float)
+
+
+# cv_results should have one row per sampled candidate, sorted best-first.
+def test_tune_random_forest_cv_results_shape(sample_df):
+    big_df = pd.concat([sample_df] * 4, ignore_index=True)
+    big_df["track_id"] = [str(i) for i in range(len(big_df))]
+    processed = preprocess_data(big_df)
+    X_train, _, y_train, _ = split_data(processed, test_size=0.25)
+
+    result = tune_random_forest(X_train, y_train, n_iter=3, cv=2)
+    cv_results = result["cv_results"]
+
+    assert isinstance(cv_results, pd.DataFrame)
+    assert len(cv_results) == 3
+    assert {"params", "mean_test_score", "rank_test_score"} <= set(cv_results.columns)
+    assert cv_results.iloc[0]["rank_test_score"] == 1
+
+
+# Custom param distributions should be used instead of the defaults.
+def test_tune_random_forest_respects_custom_distributions(sample_df):
+    big_df = pd.concat([sample_df] * 4, ignore_index=True)
+    big_df["track_id"] = [str(i) for i in range(len(big_df))]
+    processed = preprocess_data(big_df)
+    X_train, _, y_train, _ = split_data(processed, test_size=0.25)
+
+    custom = {"n_estimators": [10], "max_depth": [3]}
+    result = tune_random_forest(X_train, y_train, param_distributions=custom, n_iter=1, cv=2)
+
+    assert result["best_params"]["n_estimators"] == 10
+    assert result["best_params"]["max_depth"] == 3
+
+
+# Default distributions should expose the documented hyperparameters.
+def test_default_rf_param_distributions_contains_expected_keys():
+    assert {"n_estimators", "max_depth", "min_samples_split", "max_features"} <= set(
+        DEFAULT_RF_PARAM_DISTRIBUTIONS.keys()
+    )
+
 
 # Passing save_results=False should skip writing files.
 def test_run_popularity_pipeline_skips_saving_when_disabled(


### PR DESCRIPTION
## Summary

Adds 5 useful additions in the predictive-modeling space, expanding what the project can do without duplicating existing functionality. Two new modules (`genre_classifier`, `clustering`) introduce new modeling tasks; three sets of additions extend existing modules with tuning, persistence, and threshold-optimization helpers.

All additions stay on the current dependency stack (numpy / pandas / scikit-learn / scipy / matplotlib). `joblib` is used for model persistence and ships with scikit-learn, so no `pyproject.toml` changes.

## What's new

### 1. Hyperparameter tuning — `popularity.py`, `hit_shape_predictor.py`

- `tune_random_forest(X_train, y_train, ...)` in `popularity.py` and `tune_random_forest_classifier(...)` in `hit_shape_predictor.py`
- Wraps `RandomizedSearchCV` with sensible default search spaces (`DEFAULT_RF_PARAM_DISTRIBUTIONS`, `DEFAULT_RF_CLF_PARAM_DISTRIBUTIONS`)
- Returns `{best_estimator, best_params, best_score, cv_results}`. `cv_results` is a tidy DataFrame ranked best-first
- Replaces the previous "hardcoded `RF_PARAMS`, no way to tune" gap

### 2. Decision-threshold optimization — `hit_shape_predictor.py`

- `compute_threshold_curve(model, X_val, y_val)` — sweeps probability thresholds and returns a DataFrame with `accuracy / precision / recall / f1` per threshold
- `find_optimal_threshold(model, X_val, y_val, metric='f1')` — picks the threshold that maximizes the chosen metric and returns the full curve alongside it
- `predict_with_threshold(model, X, threshold)` — applies a custom probability cutoff
- Hits are imbalanced, so the F1-optimal threshold is rarely 0.5; the previous pipeline was implicitly stuck there

### 3. Model persistence — `io.py`

- `save_model(model, path, metadata=None)` — `joblib.dump` plus a JSON sidecar (`<path>.meta.json`) recording `model_class`, `sklearn_version`, `trained_at_utc`, and any caller-supplied keys (e.g. `feature_names`, `target`)
- `load_model(path)` — returns `(model, metadata_or_None)`; works on bare joblib dumps too
- Lets users train once and reuse, instead of refitting on every pipeline call

### 4. Multi-class genre classifier — new `genre_classifier.py`

Predicts `track_genre` from audio features. Mirrors the structure of `hit_shape_predictor.py` for consistency.

- `validate_data`, `prepare_genre_data` (rare-genre filter), `split_genre_data` (stratified)
- `train_logistic_genre_classifier` (scaled multinomial Logistic Regression in a `Pipeline`) and `train_random_forest_genre_classifier`
- `top_k_accuracy(model, X, y, k=3)`, `evaluate_genre_model` (accuracy / top-k / macro F1 / weighted F1), `compare_genre_models`, `confusion_matrix_df`
- End-to-end `run_genre_classifier_pipeline(...)` that writes `genre_model_comparison.csv`, `genre_confusion_matrix.csv`, `genre_predictions.csv`

### 5. Audio-feature clustering — new `clustering.py`

Unsupervised KMeans on scaled audio features so we can discover natural song groupings (e.g. low-energy acoustic vs. high-energy electronic).

- `prepare_clustering_data` — drop NA + `StandardScaler` (uses `AUDIO_FEATURES` from constants by default)
- `find_optimal_k(X, k_range=range(2, 11))` — inertia (elbow) + silhouette per `k`, silhouette computed on a 2000-row sample for speed
- `cluster_songs(df, n_clusters=5)` — fits KMeans and attaches a `cluster` column (-1 for rows that were dropped due to NAs)
- `cluster_centroids(model, scaler, feature_names)` — centroids in original feature units
- `cluster_summary(df_with_clusters)` — per-cluster size, mean popularity, mean of each feature, top genre
- End-to-end `run_clustering_pipeline(...)` that writes `cluster_assignments.csv`, `cluster_centroids.csv`, `cluster_summary.csv`, `cluster_k_search.csv`

## Files changed

**Modified**
- `src/unwrapped/popularity.py` — `tune_random_forest`, `DEFAULT_RF_PARAM_DISTRIBUTIONS`
- `src/unwrapped/hit_shape_predictor.py` — `tune_random_forest_classifier`, `compute_threshold_curve`, `find_optimal_threshold`, `predict_with_threshold`, related constants
- `src/unwrapped/io.py` — `save_model`, `load_model`
- `tests/test_popularity.py`, `tests/test_hit_shape_predictor.py`, `tests/test_io.py` — extended with matching test coverage

**New**
- `src/unwrapped/genre_classifier.py`
- `src/unwrapped/clustering.py`
- `tests/test_genre_classifier.py`
- `tests/test_clustering.py`

All new feature lists reuse `AUDIO_FEATURES`, `AUDIO_FEATURES_WITH_DURATION`, and `AUDIO_FEATURES_FOR_HIT_CLASSIFICATION` from `constants.py` — no duplication.

## Test plan

- [x] Full suite passes locally — **301 passed** (240 existing + 61 new), no regressions
  - `PYTHONPATH=src pytest tests/ -q`
- [x] Synthetic-data tests cover validation paths, return shapes, sklearn `hasattr` checks, error paths, and end-to-end pipeline runs with `monkeypatch`'d data loading — matches existing test conventions exactly (`make_df()` helpers, no real-data loads)
- [ ] Smoke-test on the real dataset before merge:
  - `python -c "from unwrapped.genre_classifier import run_genre_classifier_pipeline; run_genre_classifier_pipeline('data/raw/spotify_data.csv')"`
  - `python -c "from unwrapped.clustering import run_clustering_pipeline; run_clustering_pipeline('data/raw/spotify_data.csv', n_clusters=5)"`
  - Train hit classifier, run `find_optimal_threshold(metric='f1')`, confirm best F1 ≥ F1 at 0.5
  - `save_model` → `load_model` round-trip, confirm predictions match