### PR TITLE
Add test coverage to README and pytest-cov to dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ Run the full test suite:
 python -m pytest
 ```
 
+To see test coverage:
+
+```bash
+python -m pytest --cov=src/unwrapped --cov-report=term-missing
+```
+
+**Current test coverage: 94%** across 271 tests. Per-module coverage:
+
+| Module | Coverage |
+|---|---|
+| `__init__.py` | 100% |
+| `constants.py` | 100% |
+| `popularity.py` | 99% |
+| `visualization.py` | 99% |
+| `summary.py` | 98% |
+| `clean.py` | 97% |
+| `preference.py` | 97% |
+| `validation.py` | 97% |
+| `analysis.py` | 93% |
+| `io.py` | 83% |
+| `feature_impact.py` | 82% |
+| `hit_shape_predictor.py` | 75% |
+
 Tests are in the `tests/` directory. They use small hand-built DataFrames so
 they run fast and don't need the real CSV file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
+  "pytest-cov>=5.0",
 ]


### PR DESCRIPTION
## Summary
Addresses the 'Test coverage is displayed on README.md' rubric item from issue #1.

- Adds `pytest-cov>=5.0` to the `[dev]` optional dependencies in pyproject.toml
- Adds a Coverage section to the README with the command to run it and a per-module breakdown
- Current overall coverage is **94%** across **271 tests**

## Test plan
- [ ] Run `pip install -e ".[dev]"` to confirm pytest-cov installs
- [ ] Run `python -m pytest --cov=src/unwrapped --cov-report=term` and verify the numbers match what's in the README