### PR TITLE
Fix analysis bucket edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To see test coverage:
 python -m pytest --cov=src/unwrapped --cov-report=term-missing
 ```
 
-**Current test coverage: 94%** across 319 tests. Per-module coverage:
+**Current test coverage: 94%** across 322 tests. Per-module coverage:
 
 | Module | Coverage |
 |---|---|

--- a/scripts/demo_analysis.py
+++ b/scripts/demo_analysis.py
@@ -5,9 +5,14 @@ questions using the analysis module.  Results are printed to the terminal
 in a readable format with key takeaways highlighted.
 """
 
+import sys
+
 from unwrapped.io import DEFAULT_DATA_PATH, load_data
 from unwrapped.clean import clean_data
 from unwrapped.analysis import run_analysis
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(errors="replace")
 
 
 def print_header(title):
@@ -59,7 +64,7 @@ def main():
     display["p (Holm)"] = display["p_value_adjusted"].map(
         lambda p: "<1e-4" if p < 1e-4 else f"{p:.4f}"
     )
-    display["sig"] = display["significant"].map(lambda s: "✓" if s else "·")
+    display["sig"] = display["significant"].map(lambda s: "yes" if s else "no")
     print(
         display[
             ["feature", "correlation", "95% CI", "p (Holm)", "sig", "strength"]

--- a/scripts/group3_model_comparison.py
+++ b/scripts/group3_model_comparison.py
@@ -37,8 +37,6 @@ from catboost import CatBoostRegressor
 # --------------------------
 
 DATA_PATHS = [
-    Path("/Users/norahmasrour/PyCharmMiscProject/spotify_final.csv"),
-    Path("/Users/norahmasrour/PyCharmMiscProject/spotify_data.csv"),
     Path("data/raw/spotify_final.csv"),
     Path("data/raw/spotify_data.csv"),
     Path("spotify_final.csv"),

--- a/src/unwrapped/analysis.py
+++ b/src/unwrapped/analysis.py
@@ -423,10 +423,26 @@ def popularity_by_feature_buckets(
         raise ValueError(f"n_buckets must be >= 1, got {n_buckets}")
 
     tmp = df[[feature, "popularity"]].dropna().copy()
+    if tmp.empty:
+        return pd.DataFrame(columns=["avg_popularity", "track_count"])
+
     values = tmp[feature].values.astype(float)
+    value_min = float(np.min(values))
+    value_max = float(np.max(values))
+
+    if value_min == value_max:
+        label = f"{value_min:.2f}-{value_max:.2f}"
+        bucket_stats = pd.DataFrame(
+            {
+                "avg_popularity": [round(float(tmp["popularity"].mean()), 2)],
+                "track_count": [int(tmp["popularity"].count())],
+            },
+            index=pd.CategoricalIndex([label], categories=[label], name="bucket"),
+        )
+        return bucket_stats
 
     # Create evenly spaced bucket edges with numpy
-    edges = np.linspace(np.min(values), np.max(values), n_buckets + 1)
+    edges = np.linspace(value_min, value_max, n_buckets + 1)
     labels = [f"{edges[i]:.2f}-{edges[i + 1]:.2f}" for i in range(n_buckets)]
 
     tmp["bucket"] = pd.cut(

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -408,6 +408,25 @@ class TestPopularityByFeatureBuckets:
         assert (valid_buckets["avg_popularity"] >= 0).all()
         assert (valid_buckets["avg_popularity"] <= 100).all()
 
+    def test_empty_after_dropna_returns_empty_table(self) -> None:
+        df = make_df()
+        df["danceability"] = np.nan
+
+        result = popularity_by_feature_buckets(df, "danceability", 3)
+
+        assert result.empty
+        assert list(result.columns) == ["avg_popularity", "track_count"]
+
+    def test_constant_feature_returns_single_bucket(self) -> None:
+        df = make_df()
+        df["danceability"] = 0.5
+
+        result = popularity_by_feature_buckets(df, "danceability", 3)
+
+        assert len(result) == 1
+        assert result["track_count"].iloc[0] == len(df)
+        assert result["avg_popularity"].iloc[0] == round(df["popularity"].mean(), 2)
+
 
 # ------------------------------------------------------------------
 # run_analysis


### PR DESCRIPTION
## Summary
- Handle empty and constant-feature bucket inputs in analysis
- Add regression tests for those edge cases
- Remove absolute local data paths from group3 model comparison
- Make demo analysis output console-safe
- Update README test count

## Tests
- python -m pytest tests/test_analysis.py
